### PR TITLE
update style to pass ament_cpplint

### DIFF
--- a/ament_index_cpp/include/ament_index_cpp/get_resource.hpp
+++ b/ament_index_cpp/include/ament_index_cpp/get_resource.hpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef __ament_index_cpp__get_resource__h__
-#define __ament_index_cpp__get_resource__h__
+#ifndef AMENT_INDEX_CPP__GET_RESOURCE_HPP_
+#define AMENT_INDEX_CPP__GET_RESOURCE_HPP_
 
 #include <string>
 
-#include <ament_index_cpp/visibility_control.h>
+#include "ament_index_cpp/visibility_control.h"
 
 namespace ament_index_cpp
 {
@@ -29,6 +29,6 @@ get_resource(
   const std::string & resource_name,
   std::string & content);
 
-}  // namespace
+}  // namespace ament_index_cpp
 
-#endif  // __ament_index_cpp__get_resource__h__
+#endif  // AMENT_INDEX_CPP__GET_RESOURCE_HPP_

--- a/ament_index_cpp/include/ament_index_cpp/get_resources.hpp
+++ b/ament_index_cpp/include/ament_index_cpp/get_resources.hpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef __ament_index_cpp__get_resources__h__
-#define __ament_index_cpp__get_resources__h__
+#ifndef AMENT_INDEX_CPP__GET_RESOURCES_HPP_
+#define AMENT_INDEX_CPP__GET_RESOURCES_HPP_
 
 #include <map>
 #include <string>
 
-#include <ament_index_cpp/visibility_control.h>
+#include "ament_index_cpp/visibility_control.h"
 
 namespace ament_index_cpp
 {
@@ -27,6 +27,6 @@ AMENT_INDEX_CPP_PUBLIC
 std::map<std::string, std::string>
 get_resources(const std::string & resource_type);
 
-}  // namespace
+}  // namespace ament_index_cpp
 
-#endif  // __ament_index_cpp__get_resources__h__
+#endif  // AMENT_INDEX_CPP__GET_RESOURCES_HPP_

--- a/ament_index_cpp/include/ament_index_cpp/get_search_paths.hpp
+++ b/ament_index_cpp/include/ament_index_cpp/get_search_paths.hpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef __ament_index_cpp__get_search_paths__h__
-#define __ament_index_cpp__get_search_paths__h__
+#ifndef AMENT_INDEX_CPP__GET_SEARCH_PATHS_HPP_
+#define AMENT_INDEX_CPP__GET_SEARCH_PATHS_HPP_
 
 #include <list>
 #include <string>
 
-#include <ament_index_cpp/visibility_control.h>
+#include "ament_index_cpp/visibility_control.h"
 
 namespace ament_index_cpp
 {
@@ -27,6 +27,6 @@ AMENT_INDEX_CPP_PUBLIC
 std::list<std::string>
 get_search_paths();
 
-}  // namespace
+}  // namespace ament_index_cpp
 
-#endif  // __ament_index_cpp__get_search_paths__h__
+#endif  // AMENT_INDEX_CPP__GET_SEARCH_PATHS_HPP_

--- a/ament_index_cpp/src/get_resource.cpp
+++ b/ament_index_cpp/src/get_resource.cpp
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ament_index_cpp/get_resource.hpp"
+
 #include <cassert>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 
-#include <ament_index_cpp/get_resource.hpp>
-#include <ament_index_cpp/get_search_paths.hpp>
+#include "ament_index_cpp/get_search_paths.hpp"
 
 namespace ament_index_cpp
 {
@@ -50,4 +52,4 @@ get_resource(
   return false;
 }
 
-}  // namespace
+}  // namespace ament_index_cpp

--- a/ament_index_cpp/src/get_resources.cpp
+++ b/ament_index_cpp/src/get_resources.cpp
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ament_index_cpp/get_resources.hpp"
+
 #ifndef _WIN32
 #include <dirent.h>
 #else
 #include <windows.h>
 #endif
+#include <map>
 #include <stdexcept>
+#include <string>
 
-#include <ament_index_cpp/get_resources.hpp>
-#include <ament_index_cpp/get_search_paths.hpp>
+#include "ament_index_cpp/get_search_paths.hpp"
 
 namespace ament_index_cpp
 {
@@ -71,4 +74,4 @@ get_resources(const std::string & resource_type)
   return resources;
 }
 
-}  // namespace
+}  // namespace ament_index_cpp

--- a/ament_index_cpp/src/get_search_paths.cpp
+++ b/ament_index_cpp/src/get_search_paths.cpp
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <sstream>
-#include <stdexcept>
+#include "ament_index_cpp/get_search_paths.hpp"
+
 #include <sys/stat.h>
 
-#include <ament_index_cpp/get_search_paths.hpp>
+#include <list>
+#include <sstream>
+#include <stdexcept>
+#include <string>
 
 #ifdef _WIN32
 #define stat _stat
@@ -74,4 +77,4 @@ get_search_paths()
   return paths;
 }
 
-}  // namespace
+}  // namespace ament_index_cpp

--- a/ament_index_cpp/test/utest.cpp
+++ b/ament_index_cpp/test/utest.cpp
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdexcept>
-#include <stdlib.h>
-
 #include <gtest/gtest.h>
 
-#include <ament_index_cpp/get_resource.hpp>
-#include <ament_index_cpp/get_resources.hpp>
-#include <ament_index_cpp/get_search_paths.hpp>
+#include <stdlib.h>
+
+#include <list>
+#include <map>
+#include <stdexcept>
+#include <string>
+
+#include "ament_index_cpp/get_resource.hpp"
+#include "ament_index_cpp/get_resources.hpp"
+#include "ament_index_cpp/get_search_paths.hpp"
 
 void set_ament_prefix_path(std::list<std::string> subfolders)
 {


### PR DESCRIPTION
This patch updates the code to follow ament_cppling (which is essentially Google's style guide with some minor changes). We need to find a consensus if we want to use this as our style guide. E.g. the repeated includes in the cpp files are something which we currently don't do.

Connect to ament/ament_lint#31
