### PR TITLE
fix finding resources in overlayed workspaces

### DIFF
--- a/ament_index_cpp/src/get_resources.cpp
+++ b/ament_index_cpp/src/get_resources.cpp
@@ -50,7 +50,9 @@ get_resources(const std::string & resource_type)
       if (entry->d_name[0] == '.') {
         continue;
       }
-      resources[entry->d_name] = base_path;
+      if (resources.find(entry->d_name) == resources.end()) {
+        resources[entry->d_name] = base_path;
+      }
     }
     closedir(dir);
 
@@ -64,12 +66,13 @@ get_resources(const std::string & resource_type)
     do {
       // ignore directories
       if ((find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-        resources[find_data.cFileName] = base_path;
+        if (resources.find(find_data.cFileName) == resources.end()) {
+          resources[find_data.cFileName] = base_path;
+        }
       }
     } while (FindNextFile(find_handle, &find_data));
     FindClose(find_handle);
 #endif
-    break;
   }
   return resources;
 }

--- a/ament_index_python/ament_index_python/__init__.py
+++ b/ament_index_python/ament_index_python/__init__.py
@@ -72,8 +72,8 @@ def get_resources(resource_type):
         resource_path = os.path.join(path, RESOURCE_INDEX_SUBFOLDER, resource_type)
         if os.path.isdir(resource_path):
             for filename in os.listdir(resource_path):
-                resources[filename] = path
-            break
+                if filename not in resources:
+                    resources[filename] = path
     return resources
 
 


### PR DESCRIPTION
Before when finding any resource in a workspace aborted searching in underlayed workspaces. Instead we always have to consider all workspaces but only use the highest level entry with the same name.
