### PR TITLE
Add python build dependencies.

### DIFF
--- a/ament_index_python/package.xml
+++ b/ament_index_python/package.xml
@@ -9,11 +9,9 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
-  <build_depend>python3-setuptools</build_depend>
+  <buildtool_depend>python3-setuptools</buildtool_depend>
 
   <exec_depend>python3</exec_depend>
-
-  <buildtool_export_depend>python3</buildtool_export_depend>
 
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_pep8</test_depend>

--- a/ament_index_python/package.xml
+++ b/ament_index_python/package.xml
@@ -11,7 +11,7 @@
 
   <build_depend>python3-setuptools</build_depend>
 
-  <buildtool_depend>python3</buildtool_depend>
+  <exec_depend>python3</exec_depend>
 
   <buildtool_export_depend>python3</buildtool_export_depend>
 

--- a/ament_index_python/package.xml
+++ b/ament_index_python/package.xml
@@ -9,6 +9,12 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
+  <buildtool_depend>python3</buildtool_depend>
+
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_pep8</test_depend>
   <test_depend>ament_pyflakes</test_depend>


### PR DESCRIPTION
In order to be packaged with ament_python + bloom these build dependencies are required.