### PR TITLE
set zip_safe to avoid warning during installation

### DIFF
--- a/ament_index_python/setup.py
+++ b/ament_index_python/setup.py
@@ -6,6 +6,7 @@ setup(
     version='0.4.0',
     packages=find_packages(exclude=['test']),
     install_requires=['setuptools'],
+    zip_safe=True,
     author='Dirk Thomas',
     author_email='dthomas@osrfoundation.org',
     maintainer='Dirk Thomas',


### PR DESCRIPTION
http://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag