### PR TITLE
pass HAS_LIBRARY_TARGET to ament_export_interfaces

### DIFF
--- a/ament_index_cpp/CMakeLists.txt
+++ b/ament_index_cpp/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<INSTALL_INTERFACE:include>")
 
 ament_export_include_directories(include)
-ament_export_interfaces(export_${PROJECT_NAME})
+ament_export_interfaces(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_libraries(${PROJECT_NAME})
 
 if(BUILD_TESTING)


### PR DESCRIPTION
Connect to ament/ament_cmake#135.

While not necessary (since the CMake also calls `ament_export_libraries`) this is the correct way of doing it now.