### PR TITLE
Use EXCLUDE argument of ament_lint_auto to skip cppcheck:

### DIFF
--- a/ament_index_cpp/CMakeLists.txt
+++ b/ament_index_cpp/CMakeLists.txt
@@ -39,9 +39,10 @@ ament_export_libraries(${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-  # prevent cppcheck from being found, since it fails to process the file utest.cpp
-  set(ament_cmake_cppcheck_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
+  ament_lint_auto_find_test_dependencies(
+    EXCLUDE
+    ament_cmake_cppcheck
+  )
 
   ament_add_gtest(${PROJECT_NAME}_utest test/utest.cpp)
   if(TARGET ${PROJECT_NAME}_utest)


### PR DESCRIPTION
- This is an example of https://github.com/ament/ament_lint/pull/133

(FYI, while testing this, I found that `cppcheck` wasn't actually failing for this package)