### PR TITLE
enable cppcheck

### DIFF
--- a/ament_index_cpp/CMakeLists.txt
+++ b/ament_index_cpp/CMakeLists.txt
@@ -39,8 +39,6 @@ ament_export_libraries(${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-  # prevent cppcheck from being found, since it fails to process the file utest.cpp
-  set(ament_cmake_cppcheck_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(${PROJECT_NAME}_utest test/utest.cpp)


### PR DESCRIPTION
It looks like `cppcheck` passes now so no need to skip it anymore.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6514)](https://ci.ros2.org/job/ci_linux/6514/)