### PR TITLE
fix completion of first arg

### DIFF
--- a/ament_index_python/ament_index_python/cli.py
+++ b/ament_index_python/ament_index_python/cli.py
@@ -68,7 +68,9 @@ def resource_type_completer(prefix, **kwargs):
 
 
 def resource_name_completer(prefix, parsed_args, **kwargs):
-    resource_type = getattr(parsed_args, 'resource_type')
+    resource_type = getattr(parsed_args, 'resource_type', None)
+    if not resource_type:
+        return []
     return get_resources(resource_type).keys()
 
 


### PR DESCRIPTION
Follow up of #35.

The completion for the first argument fails atm because the second completion function is also trigger (since both are optional) and that function raises an exception if the first argument is not provided.