### PR TITLE
Fix resource name autocompleter in ament_index CLI

### DIFF
--- a/ament_index_python/ament_index_python/cli.py
+++ b/ament_index_python/ament_index_python/cli.py
@@ -71,7 +71,7 @@ def resource_name_completer(prefix, parsed_args, **kwargs):
     resource_type = getattr(parsed_args, 'resource_type', None)
     if not resource_type:
         return []
-    return get_resources(resource_type).keys()
+    return (t for t in list(get_resources(resource_type).keys()) if t.startswith(prefix))
 
 
 if __name__ == '__main__':

--- a/ament_index_python/ament_index_python/cli.py
+++ b/ament_index_python/ament_index_python/cli.py
@@ -71,7 +71,7 @@ def resource_name_completer(prefix, parsed_args, **kwargs):
     resource_type = getattr(parsed_args, 'resource_type', None)
     if not resource_type:
         return []
-    return (t for t in list(get_resources(resource_type).keys()) if t.startswith(prefix))
+    return (t for t in get_resources(resource_type).keys() if t.startswith(prefix))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Function resource_name_completer did not use the prefix argument, resulting in the tool including all resources available when it has to return the resources matching the typed text already available.