### PR TITLE
Code refactors to the ament_index_python test

### DIFF
--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -150,11 +150,11 @@ def test_get_package_share_directory():
     def get_package_share_directory_test(package_name, expect_prefix):
         full_share_dir = get_package_share_directory(package_name)
         left_over, dirname = os.path.split(full_share_dir)
-        assert dirname == package_name, "Expected package name '{}'".format(package_name)
+        assert dirname == package_name, f"Expected package name '{package_name}'"
         left_over, dirname = os.path.split(left_over)
         assert dirname == 'share', "Expected 'share'"
         left_over, dirname = os.path.split(left_over)
-        assert dirname == expect_prefix, "Expected '{}'".format(expect_prefix)
+        assert dirname == expect_prefix, f"Expected '{expect_prefix}'"
 
     get_package_share_directory_test('foo', 'prefix1')
     # found in both prefix1 and prefix2, but prefix1 is ahead on the APP

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -142,6 +142,7 @@ def test_get_package_prefix():
 
     with pytest.raises(PackageNotFoundError):
         get_package_prefix('does_not_exist')
+    assert issubclass(PackageNotFoundError, KeyError)
 
 
 def test_get_package_share_directory():

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from pathlib import Path
+from pathlib import Path, PurePath
 
 from ament_index_python import get_package_prefix
 from ament_index_python import get_package_share_directory
@@ -33,11 +33,11 @@ import pytest
 
 def set_ament_prefix_path(subfolders):
     paths = []
-    base_path = os.path.dirname(__file__)
+    base_path = Path(__file__).parent
     for subfolder in subfolders:
-        path = os.path.join(base_path, subfolder)
-        if os.path.isdir(path):
-            paths.append(path)
+        path = base_path / subfolder
+        if path.is_dir():
+            paths.append(str(path))
     ament_prefix_path = os.pathsep.join(paths)
     os.environ['AMENT_PREFIX_PATH'] = ament_prefix_path
 
@@ -103,7 +103,7 @@ def test_resource():
 
     resource, prefix = get_resource('resource_type4', 'foo')
     assert resource == 'foo', 'Expected different content'
-    assert os.path.basename(prefix) == 'prefix1', 'Expected different prefix'
+    assert PurePath(prefix).name == 'prefix1', 'Expected different prefix'
 
 
 def test_resource_overlay():
@@ -111,7 +111,7 @@ def test_resource_overlay():
 
     resource, prefix = get_resource('resource_type5', 'foo')
     assert resource == 'foo1', 'Expected different content'
-    assert os.path.basename(prefix) == 'prefix1', 'Expected different prefix'
+    assert PurePath(prefix).name == 'prefix1', 'Expected different prefix'
 
 
 def test_get_packages_with_prefixes():
@@ -119,12 +119,11 @@ def test_get_packages_with_prefixes():
 
     packages = get_packages_with_prefixes()
     assert 'foo' in packages, "Expected to find 'foo'"
-    assert os.path.basename(packages['foo']) == 'prefix1', "Expected to find 'foo' in 'prefix1'"
+    assert PurePath(packages['foo']).name == 'prefix1', "Expected to find 'foo' in 'prefix1'"
     assert 'bar' in packages, "Expected to find 'bar'"
-    assert os.path.basename(packages['bar']) == 'prefix1', "Expected to find 'bar' in 'prefix1'"
+    assert PurePath(packages['bar']).name == 'prefix1', "Expected to find 'bar' in 'prefix1'"
     assert 'baz' in packages, "Expected to find 'baz'"
-    assert os.path.basename(packages['baz']) == 'prefix2', "Expected to find 'baz' in 'prefix2'"
-
+    assert PurePath(packages['baz']).name == 'prefix2', "Expected to find 'baz' in 'prefix2'"
     os.environ['AMENT_PREFIX_PATH'] = '/path/does/not/exist'
 
     assert not get_packages_with_prefixes(), 'Expected to find no packages'
@@ -134,7 +133,7 @@ def test_get_package_prefix():
     set_ament_prefix_path(['prefix1', 'prefix2'])
 
     def get_package_prefix_basename(package_name):
-        return os.path.basename(get_package_prefix(package_name))
+        return PurePath(get_package_prefix(package_name)).name
 
     assert get_package_prefix_basename('foo') == 'prefix1', "Expected 'foo' in 'prefix1'"
     # found in both prefix1 and prefix2, but prefix1 is ahead on the APP

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -136,7 +136,6 @@ def test_get_package_prefix():
         return PurePath(get_package_prefix(package_name)).name
 
     assert get_package_prefix_basename('foo') == 'prefix1', "Expected 'foo' in 'prefix1'"
-    # found in both prefix1 and prefix2, but prefix1 is ahead on the APP
     assert get_package_prefix_basename('bar') == 'prefix1', "Expected 'bar' in 'prefix2'"
     assert get_package_prefix_basename('baz') == 'prefix2', "Expected 'baz' in 'prefix2'"
 
@@ -157,7 +156,6 @@ def test_get_package_share_directory():
         assert dirname == expect_prefix, f"Expected '{expect_prefix}'"
 
     get_package_share_directory_test('foo', 'prefix1')
-    # found in both prefix1 and prefix2, but prefix1 is ahead on the APP
     get_package_share_directory_test('bar', 'prefix1')
     get_package_share_directory_test('baz', 'prefix2')
 

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -44,13 +44,8 @@ def set_ament_prefix_path(subfolders):
 
 def test_empty_search_paths():
     set_ament_prefix_path([])
-    try:
+    with pytest.raises(EnvironmentError):
         get_search_paths()
-        assert False, 'get_search_paths() failed to raise exception'
-    except EnvironmentError:
-        pass
-    except Exception as e:
-        assert False, 'get_search_paths() raised wrong exception: ' + type(e)
 
 
 def test_search_paths():
@@ -97,13 +92,8 @@ def test_unknown_resource():
     exists = has_resource('resource_type4', 'bar')
     assert not exists, 'Resource should not exist'
 
-    try:
+    with pytest.raises(LookupError):
         get_resource('resource_type4', 'bar')
-        assert False, 'get_resource() failed to raise exception'
-    except LookupError:
-        pass
-    except Exception as e:
-        assert False, 'get_resource() raised wrong exception: ' + type(e)
 
 
 def test_resource():
@@ -151,19 +141,8 @@ def test_get_package_prefix():
     assert get_package_prefix_basename('bar') == 'prefix1', "Expected 'bar' in 'prefix2'"
     assert get_package_prefix_basename('baz') == 'prefix2', "Expected 'baz' in 'prefix2'"
 
-    try:
+    with pytest.raises(PackageNotFoundError):
         get_package_prefix('does_not_exist')
-    except PackageNotFoundError:
-        pass
-    except Exception as exc:
-        assert False, 'Expected PackageNotFoundError, got: {}'.format(type(exc))
-
-    try:
-        get_package_prefix('does_not_exist')
-    except KeyError:
-        pass
-    except Exception as exc:
-        assert False, 'Expected KeyError or subclass, got: {}'.format(type(exc))
 
 
 def test_get_package_share_directory():
@@ -183,12 +162,8 @@ def test_get_package_share_directory():
     get_package_share_directory_test('bar', 'prefix1')
     get_package_share_directory_test('baz', 'prefix2')
 
-    try:
+    with pytest.raises(PackageNotFoundError):
         get_package_share_directory('does_not_exist')
-    except PackageNotFoundError:
-        pass
-    except Exception as exc:
-        assert False, 'Expected PackageNotFoundError, got: {}'.format(type(exc))
 
 
 def test_get_resource_types():

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -136,6 +136,7 @@ def test_get_package_prefix():
         return PurePath(get_package_prefix(package_name)).name
 
     assert get_package_prefix_basename('foo') == 'prefix1', "Expected 'foo' in 'prefix1'"
+    # found in both prefix1 and prefix2, but prefix1 is ahead on the APP
     assert get_package_prefix_basename('bar') == 'prefix1', "Expected 'bar' in 'prefix2'"
     assert get_package_prefix_basename('baz') == 'prefix2', "Expected 'baz' in 'prefix2'"
 
@@ -156,6 +157,7 @@ def test_get_package_share_directory():
         assert dirname == expect_prefix, f"Expected '{expect_prefix}'"
 
     get_package_share_directory_test('foo', 'prefix1')
+    # found in both prefix1 and prefix2, but prefix1 is ahead on the APP
     get_package_share_directory_test('bar', 'prefix1')
     get_package_share_directory_test('baz', 'prefix2')
 


### PR DESCRIPTION
The refactors are submitted in different commits for easier tracking, these are:

* Replace try/except to catch exceptions, using the with context clause now
* pathlib preferred over os.path functions
* Replace format with f-strings
* Removing comments