### PR TITLE
Refactor paths to use rcpputils filesystem helper

### DIFF
--- a/ament_index_cpp/CMakeLists.txt
+++ b/ament_index_cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ unless the library was explicitly added as a static library."
   ON)
 
 find_package(ament_cmake REQUIRED)
+find_package(rcpputils REQUIRED)
 
 add_library(${PROJECT_NAME}
   src/get_package_prefix.cpp
@@ -32,6 +33,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "AMENT_INDEX_CPP_BUILDING_DLL
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
+ament_target_dependencies(${PROJECT_NAME} rcpputils)
 
 ament_export_include_directories(include)
 ament_export_interfaces(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/ament_index_cpp/package.xml
+++ b/ament_index_cpp/package.xml
@@ -11,6 +11,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rcpputils</depend>
+  
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/ament_index_cpp/src/get_package_share_directory.cpp
+++ b/ament_index_cpp/src/get_package_share_directory.cpp
@@ -16,8 +16,9 @@
 
 #include <string>
 
-#include "ament_index_cpp/get_package_prefix.hpp"
 #include "rcpputils/filesystem_helper.hpp"
+
+#include "ament_index_cpp/get_package_prefix.hpp"
 
 namespace ament_index_cpp
 {

--- a/ament_index_cpp/src/get_package_share_directory.cpp
+++ b/ament_index_cpp/src/get_package_share_directory.cpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "ament_index_cpp/get_package_prefix.hpp"
+#include "rcpputils/filesystem_helper.hpp"
 
 namespace ament_index_cpp
 {
@@ -24,7 +25,9 @@ namespace ament_index_cpp
 std::string
 get_package_share_directory(const std::string & package_name)
 {
-  return get_package_prefix(package_name) + "/share/" + package_name;
+  auto share_directory =
+    rcpputils::fs::path{get_package_prefix(package_name)} / "share" / package_name;
+  return share_directory.string();
 }
 
 }  // namespace ament_index_cpp

--- a/ament_index_cpp/src/get_resource.cpp
+++ b/ament_index_cpp/src/get_resource.cpp
@@ -42,7 +42,7 @@ get_resource(
   auto paths = get_search_paths();
   for (auto path : paths) {
     auto resource_path = rcpputils::fs::path{path} / "share" / "ament_index" / "resource_index" /
-      resource_type / resource_name;
+    resource_type / resource_name;
     std::ifstream s(resource_path.string());
     if (s.is_open()) {
       std::stringstream buffer;

--- a/ament_index_cpp/src/get_resource.cpp
+++ b/ament_index_cpp/src/get_resource.cpp
@@ -19,8 +19,9 @@
 #include <stdexcept>
 #include <string>
 
-#include "ament_index_cpp/get_search_paths.hpp"
 #include "rcpputils/filesystem_helper.hpp"
+
+#include "ament_index_cpp/get_search_paths.hpp"
 
 namespace ament_index_cpp
 {

--- a/ament_index_cpp/src/get_resource.cpp
+++ b/ament_index_cpp/src/get_resource.cpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "ament_index_cpp/get_search_paths.hpp"
+#include "rcpputils/filesystem_helper.hpp"
 
 namespace ament_index_cpp
 {
@@ -39,9 +40,9 @@ get_resource(
   }
   auto paths = get_search_paths();
   for (auto path : paths) {
-    auto resource_path = path + "/share/ament_index/resource_index/" +
-      resource_type + "/" + resource_name;
-    std::ifstream s(resource_path);
+    auto resource_path = rcpputils::fs::path{path} / "share" / "ament_index" / "resource_index" /
+      resource_type / resource_name;
+    std::ifstream s(resource_path.string());
     if (s.is_open()) {
       std::stringstream buffer;
       buffer << s.rdbuf();

--- a/ament_index_cpp/src/get_resources.cpp
+++ b/ament_index_cpp/src/get_resources.cpp
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "ament_index_cpp/get_search_paths.hpp"
+#include "rcpputils/filesystem_helper.hpp"
 
 namespace ament_index_cpp
 {
@@ -38,17 +39,18 @@ get_resources(const std::string & resource_type)
   std::map<std::string, std::string> resources;
   auto paths = get_search_paths();
   for (auto base_path : paths) {
-    auto path = base_path + "/share/ament_index/resource_index/" + resource_type;
+    auto path =
+      rcpputils::fs::path{base_path} / "share" / "ament_index" / "resource_index" / resource_type;
 
 #ifndef _WIN32
-    auto dir = opendir(path.c_str());
+    auto dir = opendir(path.string().c_str());
     if (!dir) {
       continue;
     }
     dirent * entry;
     while ((entry = readdir(dir)) != NULL) {
       // ignore directories
-      auto subdir = opendir((path + "/" + entry->d_name).c_str());
+      auto subdir = opendir((path / entry->d_name).string().c_str());
       if (subdir) {
         closedir(subdir);
         continue;
@@ -69,7 +71,7 @@ get_resources(const std::string & resource_type)
     closedir(dir);
 
 #else
-    std::string pattern = path + "/*";
+    std::string pattern = rcpputils::fs::path{path} / "*";
     WIN32_FIND_DATA find_data;
     HANDLE find_handle = FindFirstFile(pattern.c_str(), &find_data);
     if (find_handle == INVALID_HANDLE_VALUE) {

--- a/ament_index_cpp/src/get_resources.cpp
+++ b/ament_index_cpp/src/get_resources.cpp
@@ -24,8 +24,9 @@
 #include <stdexcept>
 #include <string>
 
-#include "ament_index_cpp/get_search_paths.hpp"
 #include "rcpputils/filesystem_helper.hpp"
+
+#include "ament_index_cpp/get_search_paths.hpp"
 
 namespace ament_index_cpp
 {

--- a/ament_index_cpp/src/get_resources.cpp
+++ b/ament_index_cpp/src/get_resources.cpp
@@ -72,7 +72,7 @@ get_resources(const std::string & resource_type)
     closedir(dir);
 
 #else
-    std::string pattern = rcpputils::fs::path{path} / "*";
+    const auto pattern = (path / "*").string();
     WIN32_FIND_DATA find_data;
     HANDLE find_handle = FindFirstFile(pattern.c_str(), &find_data);
     if (find_handle == INVALID_HANDLE_VALUE) {

--- a/ament_index_cpp/src/has_resource.cpp
+++ b/ament_index_cpp/src/has_resource.cpp
@@ -17,7 +17,8 @@
 #include <fstream>
 #include <stdexcept>
 #include <string>
-#include <rcpputils/filesystem_helper.hpp>
+
+#include "rcpputils/filesystem_helper.hpp"
 
 #include "ament_index_cpp/get_search_paths.hpp"
 

--- a/ament_index_cpp/src/has_resource.cpp
+++ b/ament_index_cpp/src/has_resource.cpp
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <stdexcept>
 #include <string>
+#include <rcpputils/filesystem_helper.hpp>
 
 #include "ament_index_cpp/get_search_paths.hpp"
 
@@ -37,9 +38,9 @@ has_resource(
   }
   auto paths = get_search_paths();
   for (auto path : paths) {
-    auto resource_path = path + "/share/ament_index/resource_index/" +
-      resource_type + "/" + resource_name;
-    std::ifstream s(resource_path);
+    auto resource_path = rcpputils::fs::path{path} / "share" / "ament_index" / "resource_index" /
+      resource_type / resource_name;
+    std::ifstream s(resource_path.string());
     if (s.is_open()) {
       if (prefix_path) {
         *prefix_path = path;

--- a/ament_index_cpp/src/has_resource.cpp
+++ b/ament_index_cpp/src/has_resource.cpp
@@ -40,7 +40,7 @@ has_resource(
   auto paths = get_search_paths();
   for (auto path : paths) {
     auto resource_path = rcpputils::fs::path{path} / "share" / "ament_index" / "resource_index" /
-      resource_type / resource_name;
+    resource_type / resource_name;
     std::ifstream s(resource_path.string());
     if (s.is_open()) {
       if (prefix_path) {

--- a/ament_index_cpp/test/utest.cpp
+++ b/ament_index_cpp/test/utest.cpp
@@ -21,6 +21,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "rcpputils/filesystem_helper.hpp"
+
 #include "ament_index_cpp/get_package_prefix.hpp"
 #include "ament_index_cpp/get_package_share_directory.hpp"
 #include "ament_index_cpp/get_packages_with_prefixes.hpp"
@@ -253,8 +255,10 @@ TEST(AmentIndexCpp, get_package_share_directory) {
   subfolders.push_back("prefix2");  // only contains bar and baz packages
   set_ament_prefix_path(subfolders);
   // bar is in both, but prefix 1 takes precedence
+  const auto subfolder_path =
+    rcpputils::fs::path{generate_subfolder_path("prefix1")} / "share" / "bar";
   EXPECT_EQ(
-    generate_subfolder_path("prefix1") + "/share/bar",
+    subfolder_path.string(),
     ament_index_cpp::get_package_share_directory("bar"));
 }
 


### PR DESCRIPTION
The purpose of this refactor is to provide proper path support for both Linux and Windows systems. The previous implementation hard codes forward slashes which are not the convention on Windows systems. Using the filesystem helper in `rcpputils` resolves this.
Using `rcpputils` pulls in the dependency on `rcutils` for this package as well.

I didn't change on the return signatures for the methods to avoid breaking any previous workflows.

Resolves #45 

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>