### PR TITLE
Address clang-tidy warnings

### DIFF
--- a/ament_index_cpp/src/get_package_prefix.cpp
+++ b/ament_index_cpp/src/get_package_prefix.cpp
@@ -32,7 +32,7 @@ format_package_not_found_error_message(const std::string & package_name)
   for (const auto & path : search_paths) {
     message += path + ", ";
   }
-  if (search_paths.size() > 0) {
+  if (!search_paths.empty()) {
     message = message.substr(0, message.size() - 2);
   }
   return message + "]";
@@ -43,7 +43,7 @@ PackageNotFoundError::PackageNotFoundError(const std::string & _package_name)
   package_name(_package_name)
 {}
 
-PackageNotFoundError::~PackageNotFoundError() {}
+PackageNotFoundError::~PackageNotFoundError() = default;
 
 std::string
 get_package_prefix(const std::string & package_name)

--- a/ament_index_cpp/src/get_resource.cpp
+++ b/ament_index_cpp/src/get_resource.cpp
@@ -40,7 +40,7 @@ get_resource(
     throw std::runtime_error("ament_index_cpp::get_resource() resource name must not be empty");
   }
   auto paths = get_search_paths();
-  for (auto path : paths) {
+  for (const auto & path : paths) {
     auto resource_path = rcpputils::fs::path{path} / "share" / "ament_index" / "resource_index" /
     resource_type / resource_name;
     std::ifstream s(resource_path.string());

--- a/ament_index_cpp/src/get_resources.cpp
+++ b/ament_index_cpp/src/get_resources.cpp
@@ -16,7 +16,7 @@
 
 #ifndef _WIN32
 #include <dirent.h>
-#include <errno.h>
+#include <cerrno>
 #else
 #include <windows.h>
 #endif
@@ -39,7 +39,7 @@ get_resources(const std::string & resource_type)
   }
   std::map<std::string, std::string> resources;
   auto paths = get_search_paths();
-  for (auto base_path : paths) {
+  for (const auto & base_path : paths) {
     auto path =
       rcpputils::fs::path{base_path} / "share" / "ament_index" / "resource_index" / resource_type;
 
@@ -49,7 +49,7 @@ get_resources(const std::string & resource_type)
       continue;
     }
     dirent * entry;
-    while ((entry = readdir(dir)) != NULL) {
+    while ((entry = readdir(dir)) != nullptr) {
       // ignore directories
       auto subdir = opendir((path / entry->d_name).string().c_str());
       if (subdir) {

--- a/ament_index_cpp/src/get_search_paths.cpp
+++ b/ament_index_cpp/src/get_search_paths.cpp
@@ -60,7 +60,7 @@ get_search_paths()
       continue;
     }
     // skip non existing directories
-    struct stat s;
+    struct stat s{};
     if (stat(tok.c_str(), &s)) {
       continue;
     }

--- a/ament_index_cpp/src/get_search_paths.cpp
+++ b/ament_index_cpp/src/get_search_paths.cpp
@@ -60,7 +60,7 @@ get_search_paths()
       continue;
     }
     // skip non existing directories
-    struct stat s{};
+    struct stat s {};
     if (stat(tok.c_str(), &s)) {
       continue;
     }

--- a/ament_index_cpp/src/has_resource.cpp
+++ b/ament_index_cpp/src/has_resource.cpp
@@ -38,7 +38,7 @@ has_resource(
     throw std::runtime_error("ament_index_cpp::has_resource() resource name must not be empty");
   }
   auto paths = get_search_paths();
-  for (auto path : paths) {
+  for (const auto & path : paths) {
     auto resource_path = rcpputils::fs::path{path} / "share" / "ament_index" / "resource_index" /
     resource_type / resource_name;
     std::ifstream s(resource_path.string());


### PR DESCRIPTION
Change formatting and initialization of certain methods and variables to resolve clang-tidy warnings.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>