### PR TITLE
Add quality declaration ament_index_python

### DIFF
--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -1,116 +1,185 @@
 
-This document is a declaration of software quality for the `ament_index_python` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+This document is a declaration of software quality for the `ament_index_python` package, based on the guidelines in [REP-2004](https://github.com/ros-infrastructure/rep/blob/rep-2004/rep-2004.rst).
 
 # `ament_index_python` Quality Declaration
 
-The package `ament_index_python` claims to be in the **Quality Level 1** category.
+The package `ament_index_python` claims to be in the **Quality Level 4** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 1 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Quality Categories in REP-2004](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-quality-categories)
 
-## Version Policy
+## Version Policy [1]
 
-### Version Scheme
+### Version Scheme [1.i]
 
-`ament_index_python` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning), and is at or above a stable version, i.e. `>= 1.0.0`.
+`ament_index_python` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning)
 
-### API Stability Within a Released ROS Distribution
+### Version Stability [1.ii]
+
+Currently this package version is 0.8.0.''
+
+### Public API Declaration [1.iii]
+
+Not defined API for this package
+
+### API Stability Policy [1.iv]
 
 `ament_index_python` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
 
-### ABI Stability Within a Released ROS Distribution
+### ABI Stability Policy [1.v]
 
-`ament_index_python` contains python code, TODO: define policy to handle ABI for python packages of the ROS Core.
+`ament_index_python` must be concerned with ABI stability, and will maintain ABI stability within a ROS distribution.
 
-### Public API Declaration
+### ABI and ABI Stability Within a Released ROS Distribution [1.vi]
 
-TODO: Define API for this package
+`ament_index_python` will not break API nor ABI within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
 
-## Change Control Process
+## Change Control Process [2]
 
 `ament_index_python` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process).
 
-This includes:
+### Change Requests [2.i]
+All changes will occur through a pull request, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
 
-- all changes occur through a pull request
-- all pull request have two peer reviews
-- all pull request must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
-- all pull request must resolve related documentation changes before merging
+### Contributor Origin [2.ii]
+This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](./CONTRIBUTING.md)
 
-## Documentation
+### Peer Review Policy [2.iii]
+All pull request will be peer-reviewed, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
 
-### Feature Documentation
+### Continuous Integration [2.iv]
 
-TODO fix link
+All pull request must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
 
-`ament_index_python` has a [feature list](TODO) and each item in the list links to the corresponding feature documentation.
-There is documentation for all of the features, and new features require documentation before being added.
+Currently nightly results can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
+* [linux_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
 
-### Public API Documentation
+###  Documentation Policy [2.v]
 
-TODO fix link
+All pull requests must resolve related documentation changes before merging
 
-`ament_index_python` has embedded API documentation and it is generated using doxygen and is [hosted](TODO) along side the feature documentation.
-There is documentation for all of the public API, and new additions to the public API require documentation before being added.
+## Documentation [3]
 
-### License
+### Feature Documentation [3.i]
 
-The license for `ament_index_python` is Apache 2.0, and a summary is in each source file, the type is declared in the `package.xml` manifest file, and a full copy of the license is in the `LICENSE` file.
+`ament_index_python` does not have a documented feature list. Although it currently states part of its concept overview [here]([https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md](https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md))
 
-There is an automated test which runs a linter (ament_copyright) that ensures each file has a license statement.
+### Public API Documentation [3.ii]
 
-### Copyright Statements
+`ament_index_python` does not cover a public API documentation.
+
+### License [3.iii]
+
+The license for `ament_index_python` is Apache 2.0, and a summary is in each source file, the type is declared in the [`package.xml`](./package.xml) manifest file, and a full copy of the license is in the [`LICENSE`](../LICENSE) file.
+
+There is an automated test which runs a linter that ensures each file has a license statement. [Here](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/) can be found a list with the latest results of the various linters being run on the package.
+
+### Copyright Statements [3.iv]
 
 The copyright holders each provide a statement of copyright in each source code file in `ament_index_python`.
 
-There is an automated test which runs a linter (ament_copyright) that ensures each file has at least one copyright statement.
+There is an automated test which runs a linter that ensures each file has at least one copyright statement. Latest linter result report can be seen [here](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/test_copyright/) .
 
-## Testing
+## Testing [4]
 
-### Feature Testing
+### Feature Testing [4.i]
 
-Each feature in `ament_index_python` has corresponding tests which simulate typical usage, and they are located in the `test` directory.
+Each feature in `ament_index_python` has corresponding tests which simulate typical usage, and they are located in the [`test`](./test) directory.
+New features are required to have tests before being added.
+Currently nightly test results can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
+* [linux_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
+
 New features are required to have tests before being added.
 
-### Public API Testing
-TODO: Define API for this package
+### Public API Testing [4.ii]
 
-Each part of the public API have tests, and new additions or changes to the public API require tests before being added.
-The tests aim to cover both typical usage and corner cases, but are quantified by contributing to code coverage.
+As the API is not defined explicitly, this section is considered unresolved.
 
-### Coverage
 
-TODO fix link
+### Coverage [4.iii]
 
-`ament_index_python` follows the recommendations for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#coverage), and opts to use branch coverage instead of line coverage.
+`ament_index_python` follows the recommendations for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#code-coverage), and opts to use line coverage instead of branch coverage.
 
 This includes:
 
-- tracking and reporting branch coverage statistics
-- achieving and maintaining branch coverage at or above 95%
+- tracking and reporting line coverage statistics
+- achieving and maintaining a reasonable branch line coverage (90-100%)
 - no lines are manually skipped in coverage calculations
 
 Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
 
-Current coverage statistics can be viewed here: [coverage report](https://ci.ros2.org/job/ci_linux_coverage/55/cobertura/ament_index_python/)
+Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linux_coverage/lastBuild/cobertura/ament_index_python/)
 
-### Performance
+### Performance [4.iv]
 
 `ament_index_python` follows the recommendations for performance testing of Python code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#performance), and opts to do performance analysis on each release rather than each change.
+It is not yet defined if this package requires performance testing and how addresses this topic.
 
-TODO Will this package require performance testing.
+### Linters and Static Analysis [4.v]
 
-### Linters and Static Analysis
+`ament_index_python` uses and passes all the ROS2 standard linters and static analysis tools for a Python package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis). Passing implies there are no linter/static errors when testing against CI of supported platforms.
 
-`ament_index_python` uses and passes all the standard linters and static analysis tools for a Python package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis). This includes using ament_pep257 and ament_flake8 packages to analyze the code.
+Currently nightly test results can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
+* [linux_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
 
-TODO any qualifications on what "passing" means for certain linters
-
-## Dependencies
+## Dependencies [5]
 
 `ament_index_python` has no run-time or build-time dependencies that need to be considered for this declaration.
 
-## Platform Support
+## Platform Support [6]
 
 `ament_index_python` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
 
-TODO make additional statements about non-tier 1 platforms?
+# Current status Summary
+
+The chart below compares the requirements in the REP-2004 with the current state of the rcutils package.
+|Number|  Requirement| Current state |
+|--|--|--|
+|1| **Version policy** |---|
+|1.i|Version Policy available | ✓ |
+|1.ii|Stable version |☓|
+|1.iii|Declared public API|☓|
+|1.iv|API stability policy|✓|
+|1.v|ABI stability policy|✓|
+|1.vi_|API/ABI stable within ros distribution|✓|
+|2| **Change control process** |---|
+|2.i| All changes occur on change request | ✓|
+|2.ii| Contributor origin (DCO, CLA, etc) | ✓|
+|2.iii| Peer review policy | ✓ |
+|2.iv| CI policy for change requests | ✓ |
+|2.v| Documentation policy for change requests | ✓ |
+|3| **Documentation** | --- |
+|3.i| Per feature documentation | ☓ |
+|3.ii| Per public API item documentation | ☓ |
+|3.iii| Declared License(s) | ✓ |
+|3.iv| Copyright in source files| ✓ |
+|3.v.a| Quality declaration linked to README | ✓ |
+|3.v.b| Centralized declaration available for peer review |✓|
+|4| Testing | --- |
+|4.i| Feature items tests | ✓ |
+|4.ii| Public API tests | ☓ |
+|4.iii.a| Using coverage |✓ |
+|4.iii.a| Coverage policy | ✓ |
+|4.iv.a| Performance tests (if applicable) | ☓ |
+|4.iv.b| Performance tests policy| ✓ |
+|4.v.a| Code style enforcement (linters)| ✓ |
+|4.v.b| Use of static analysis tools | ✓ |
+|5| Dependencies | --- |
+|5.i| Must not have ROS lower level dependencies | ✓ |
+|5.ii| Optional ROS lower level dependencies| ✓ |
+|5.iii| Justifies quality use of non-ROS dependencies |✓|
+|6| Platform support | --- |
+|6.i| Support targets Tier1 ROS platforms| ✓ |
+|7| Security | --- |
+|7.i| Vulnerability Disclosure Policy | ☓ |
+
+Comparing this table with the [Quality Level Comparison Chart of REP2004](https://github.com/ros-infrastructure/rep/blob/d1074e43f25f957d75f50dbfda94ab10d86bcbfd/rep-2004.rst#quality-level-comparison-chart) lead us to decide that this package qualifies to Quality Level 4.

--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -114,7 +114,7 @@ This includes:
 
 Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
 
-Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linux_coverage/lastBuild/cobertura/ament_index_python/)
+Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linux_coverage/85/cobertura/ament_index_python/)
 
 ### Performance [4.iv]
 

--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -1,3 +1,4 @@
+
 This document is a declaration of software quality for the `ament_index_python` package, based on the guidelines in [REP-2004](https://github.com/ros-infrastructure/rep/blob/rep-2004/rep-2004.rst).
 
 # `ament_index_python` Quality Declaration
@@ -139,7 +140,7 @@ Currently nightly test results can be seen here:
 
 # Current status Summary
 
-The chart below compares the requirements in the REP-2004 with the current state of the rcutils package.
+The chart below compares the requirements in the REP-2004 with the current state of the `ament_index_python package`.
 |Number|  Requirement| Current state |
 |--|--|--|
 |1| **Version policy** |---|

--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -18,7 +18,7 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 
 ### Public API Declaration [1.iii]
 
-`ament_index_python` public API is composed with the functions available in the module, exported in the [init file](./ament_index_python/__init__.py) and the [command line utility script](./ament_index_python/cli.py). 
+The public API of `ament_index_python` is composed of the functions available in the module, exported in the [init file](./ament_index_python/__init__.py) and the [command line utility script](./ament_index_python/cli.py).
 
 ### API Stability Policy [1.iv]
 
@@ -38,7 +38,7 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 
 ### Change Requests [2.i]
 
-All changes will occur through a pull request, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
+All changes will occur through a pull request, check the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
 
 ### Contributor Origin [2.ii]
 
@@ -46,11 +46,11 @@ This package uses DCO as its confirmation of contributor origin policy. More inf
 
 ### Peer Review Policy [2.iii]
 
-All pull request will be peer-reviewed, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
+All pull requests will be peer-reviewed, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
 
 ### Continuous Integration [2.iv]
 
-All pull request must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
+All pull requests must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
 
 Currently nightly results can be seen here:
 * [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/ament_index_python.src.ament.ament_index.ament_index_python.test/)
@@ -70,7 +70,7 @@ All pull requests must resolve related documentation changes before merging.
 
 ### Public API Documentation [3.ii]
 
-`ament_index_python` API is not documented.
+Most `ament_index_python` API functions are documented using docstrings. However, this is not hosted anywhere.
 
 ### License [3.iii]
 
@@ -100,7 +100,7 @@ New features are required to have tests before being added.
 
 ### Public API Testing [4.ii]
 
-All the functionality of this package is tested, having lines code coverage report result of [96%](https://ci.ros2.org/job/ci_linux_coverage/85/cobertura/ament_index_python/).
+All the functionality of the declared API in this package is covered in its unit tests. Currently it has a line coverage of [96%](https://ci.ros2.org/job/ci_linux_coverage/85/cobertura/ament_index_python/).
 
 ### Coverage [4.iii]
 

--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -63,7 +63,7 @@ All pull requests must resolve related documentation changes before merging
 
 ### Feature Documentation [3.i]
 
-`ament_index_python` does not have a documented feature list. Although it currently states part of its concept overview [here]([https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md](https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md))
+`ament_index_python` does not have a documented feature list. Although it currently states part of its conceptual overview [here](https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md)
 
 ### Public API Documentation [3.ii]
 

--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -1,4 +1,5 @@
 
+
 This document is a declaration of software quality for the `ament_index_python` package, based on the guidelines in [REP-2004](https://github.com/ros-infrastructure/rep/blob/rep-2004/rep-2004.rst).
 
 # `ament_index_python` Quality Declaration
@@ -98,7 +99,7 @@ New features are required to have tests before being added.
 
 ### Public API Testing [4.ii]
 
-As the API is not defined explicitly, this section is considered unresolved.
+All the functionality of this package is tested, having lines code coverage report result of [96%](https://ci.ros2.org/job/ci_linux_coverage/85/cobertura/ament_index_python/).
 
 
 ### Coverage [4.iii]
@@ -164,7 +165,7 @@ The chart below compares the requirements in the REP-2004 with the current state
 |3.v.b| Centralized declaration available for peer review |✓|
 |4| Testing | --- |
 |4.i| Feature items tests | ✓ |
-|4.ii| Public API tests | ☓ |
+|4.ii| Public API tests | ✓ |
 |4.iii.a| Using coverage |✓ |
 |4.iii.a| Coverage policy | ✓ |
 |4.iv.a| Performance tests (if applicable) | ☓ |

--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -117,8 +117,7 @@ Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linu
 
 ### Performance [4.iv]
 
-`ament_index_python` follows the recommendations for performance testing of Python code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#performance), and opts to do performance analysis on each release rather than each change.
-It is not yet defined if this package requires performance testing and how addresses this topic.
+`ament_index_python` does not conduct performance tests. It is not yet defined if this package requires performance testing and how addresses this topic.
 
 ### Linters and Static Analysis [4.v]
 

--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -18,7 +18,7 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 
 ### Public API Declaration [1.iii]
 
-Not defined API for this package
+`ament_index_python` public API is composed with the functions available in the module, exported in the [init file](./ament_index_python/__init__.py) and the [command line utility script](./ament_index_python/cli.py). 
 
 ### API Stability Policy [1.iv]
 
@@ -70,7 +70,7 @@ All pull requests must resolve related documentation changes before merging.
 
 ### Public API Documentation [3.ii]
 
-`ament_index_python` does not cover a public API documentation.
+`ament_index_python` API is not documented.
 
 ### License [3.iii]
 
@@ -150,7 +150,7 @@ The chart below compares the requirements in the REP-2004 with the current state
 |1| **Version policy** |---|
 |1.i|Version Policy available | ✓ |
 |1.ii|Stable version |☓|
-|1.iii|Declared public API|☓|
+|1.iii|Declared public API|✓|
 |1.iv|API stability policy|✓|
 |1.v|ABI stability policy|✓|
 |1.vi_|API/ABI stable within ros distribution|✓|

--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -14,7 +14,7 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 
 ### Version Stability [1.ii]
 
-Currently this package version is 0.8.0.''
+`ament_index_python` is not yet at a stable version, i.e. >= 1.0.0"
 
 ### Public API Declaration [1.iii]
 

--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -1,5 +1,3 @@
-
-
 This document is a declaration of software quality for the `ament_index_python` package, based on the guidelines in [REP-2004](https://github.com/ros-infrastructure/rep/blob/rep-2004/rep-2004.rst).
 
 # `ament_index_python` Quality Declaration

--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -1,5 +1,3 @@
-
-
 This document is a declaration of software quality for the `ament_index_python` package, based on the guidelines in [REP-2004](https://github.com/ros-infrastructure/rep/blob/rep-2004/rep-2004.rst).
 
 # `ament_index_python` Quality Declaration
@@ -39,12 +37,15 @@ Not defined API for this package
 `ament_index_python` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process).
 
 ### Change Requests [2.i]
+
 All changes will occur through a pull request, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
 
 ### Contributor Origin [2.ii]
+
 This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](./CONTRIBUTING.md)
 
 ### Peer Review Policy [2.iii]
+
 All pull request will be peer-reviewed, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
 
 ### Continuous Integration [2.iv]
@@ -59,13 +60,13 @@ Currently nightly results can be seen here:
 
 ###  Documentation Policy [2.v]
 
-All pull requests must resolve related documentation changes before merging
+All pull requests must resolve related documentation changes before merging.
 
 ## Documentation [3]
 
 ### Feature Documentation [3.i]
 
-`ament_index_python` does not have a documented feature list. Although it currently states part of its conceptual overview [here](https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md)
+`ament_index_python` does not have a documented feature list. Although it currently states part of its conceptual overview [here](https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md).
 
 ### Public API Documentation [3.ii]
 
@@ -100,7 +101,6 @@ New features are required to have tests before being added.
 ### Public API Testing [4.ii]
 
 All the functionality of this package is tested, having lines code coverage report result of [96%](https://ci.ros2.org/job/ci_linux_coverage/85/cobertura/ament_index_python/).
-
 
 ### Coverage [4.iii]
 
@@ -137,6 +137,10 @@ Currently nightly test results can be seen here:
 ## Platform Support [6]
 
 `ament_index_python` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
+
+## Vulnerability Disclosure Policy [7.i]
+
+`ament_index_python` does not have a Vulnerability Disclosure Policy
 
 # Current status Summary
 

--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -26,11 +26,11 @@ Not defined API for this package
 
 ### ABI Stability Policy [1.v]
 
-`ament_index_python` must be concerned with ABI stability, and will maintain ABI stability within a ROS distribution.
+`ament_index_python` is a Python package, so it does not need to handle ABI stability.
 
 ### ABI and ABI Stability Within a Released ROS Distribution [1.vi]
 
-`ament_index_python` will not break API nor ABI within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+`ament_index_python` will not break API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
 
 ## Change Control Process [2]
 

--- a/ament_index_python/Quality_Declaration.md
+++ b/ament_index_python/Quality_Declaration.md
@@ -1,0 +1,116 @@
+
+This document is a declaration of software quality for the `ament_index_python` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `ament_index_python` Quality Declaration
+
+The package `ament_index_python` claims to be in the **Quality Level 1** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 1 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy
+
+### Version Scheme
+
+`ament_index_python` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning), and is at or above a stable version, i.e. `>= 1.0.0`.
+
+### API Stability Within a Released ROS Distribution
+
+`ament_index_python` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution
+
+`ament_index_python` contains python code, TODO: define policy to handle ABI for python packages of the ROS Core.
+
+### Public API Declaration
+
+TODO: Define API for this package
+
+## Change Control Process
+
+`ament_index_python` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process).
+
+This includes:
+
+- all changes occur through a pull request
+- all pull request have two peer reviews
+- all pull request must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
+- all pull request must resolve related documentation changes before merging
+
+## Documentation
+
+### Feature Documentation
+
+TODO fix link
+
+`ament_index_python` has a [feature list](TODO) and each item in the list links to the corresponding feature documentation.
+There is documentation for all of the features, and new features require documentation before being added.
+
+### Public API Documentation
+
+TODO fix link
+
+`ament_index_python` has embedded API documentation and it is generated using doxygen and is [hosted](TODO) along side the feature documentation.
+There is documentation for all of the public API, and new additions to the public API require documentation before being added.
+
+### License
+
+The license for `ament_index_python` is Apache 2.0, and a summary is in each source file, the type is declared in the `package.xml` manifest file, and a full copy of the license is in the `LICENSE` file.
+
+There is an automated test which runs a linter (ament_copyright) that ensures each file has a license statement.
+
+### Copyright Statements
+
+The copyright holders each provide a statement of copyright in each source code file in `ament_index_python`.
+
+There is an automated test which runs a linter (ament_copyright) that ensures each file has at least one copyright statement.
+
+## Testing
+
+### Feature Testing
+
+Each feature in `ament_index_python` has corresponding tests which simulate typical usage, and they are located in the `test` directory.
+New features are required to have tests before being added.
+
+### Public API Testing
+TODO: Define API for this package
+
+Each part of the public API have tests, and new additions or changes to the public API require tests before being added.
+The tests aim to cover both typical usage and corner cases, but are quantified by contributing to code coverage.
+
+### Coverage
+
+TODO fix link
+
+`ament_index_python` follows the recommendations for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#coverage), and opts to use branch coverage instead of line coverage.
+
+This includes:
+
+- tracking and reporting branch coverage statistics
+- achieving and maintaining branch coverage at or above 95%
+- no lines are manually skipped in coverage calculations
+
+Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
+
+Current coverage statistics can be viewed here: [coverage report](https://ci.ros2.org/job/ci_linux_coverage/55/cobertura/ament_index_python/)
+
+### Performance
+
+`ament_index_python` follows the recommendations for performance testing of Python code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#performance), and opts to do performance analysis on each release rather than each change.
+
+TODO Will this package require performance testing.
+
+### Linters and Static Analysis
+
+`ament_index_python` uses and passes all the standard linters and static analysis tools for a Python package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis). This includes using ament_pep257 and ament_flake8 packages to analyze the code.
+
+TODO any qualifications on what "passing" means for certain linters
+
+## Dependencies
+
+`ament_index_python` has no run-time or build-time dependencies that need to be considered for this declaration.
+
+## Platform Support
+
+`ament_index_python` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
+
+TODO make additional statements about non-tier 1 platforms?

--- a/ament_index_python/README.md
+++ b/ament_index_python/README.md
@@ -1,0 +1,5 @@
+# ament_index_python
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./Quality_Declaration.md) for more details.

--- a/ament_index_python/README.md
+++ b/ament_index_python/README.md
@@ -1,5 +1,9 @@
 # ament_index_python
 
+`ament_index_python` is a python API to access the ament resource index.
+
+See [https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md](https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md)  for documentation on the ament resource index.
+
 ## Quality Declaration
 
 This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./Quality_Declaration.md) for more details.


### PR DESCRIPTION
This is a quality declaration for ament_index_python as described in the proposed REP-2004 (see ros-infrastructure/rep#218).

This declaration is aspirational, in that it states things which aren't currently true, but we plan to do soon so we can get it up to the highest level. (EDIT: this was merged with the current state of the ament_index_python)

Checklist in #49 can be checked first to sort out missing parts of the declaration.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>