### PR TITLE
Remove the Quality Level from the README.md.

### DIFF
--- a/ament_index_cpp/README.md
+++ b/ament_index_cpp/README.md
@@ -8,4 +8,4 @@ Features are described in detail at [http://docs.ros2.org](http://docs.ros2.org/
 
 ## Quality Declaration
 
-This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](./Quality_Declaration.md) for more details.
+See the [Quality Declaration](./QUALITY_DECLARATION.md) for details on the declared Quality Level.

--- a/ament_index_python/README.md
+++ b/ament_index_python/README.md
@@ -6,4 +6,4 @@ See [https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resou
 
 ## Quality Declaration
 
-This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.
+See the [Quality Declaration](./QUALITY_DECLARATION.md) for details on the declared Quality Level.


### PR DESCRIPTION
It is duplicating information from the QUALITY_DECLARATION.md.
Just put a link to the QD, which should be good enough.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

We discussed this quite a bit over https://github.com/ament/ament_index/pull/61/files#r448358899 .  There was actually no conclusion there, but it seems to me that duplicating information that is right alongside this is just going to lead to additional maintenance in the future.  Thus, this PR de-duplicates that information.  I wanted to open this so we didn't lose track of the discussion; if there is still disagreement, we can continue the discussion here.