### PR TITLE
add rational why ament_index pkgs don't have explicit performance tests

### DIFF
--- a/ament_index_cpp/QUALITY_DECLARATION.md
+++ b/ament_index_cpp/QUALITY_DECLARATION.md
@@ -122,7 +122,7 @@ A description of how coverage statistics are summarized from this page, can be f
 ### Performance [4.iv]
 
 An environment variable defines the prefix paths of such resource indices and the API has a time complexity of `O(n)` where `n` is the number of prefix paths.
-The time complexity to query information is either scaling lineraly with the number of resource types or with the number of resources per type (depending on which dimension is requested).
+The time complexity to query information is either scaling linearly with the number of resource types or with the number of resources per type (depending on which dimension is requested).
 If the content of a specific resource is retrieved the time complexity is linear to the size of the content as is the memory usage in that case since the content is returned to the caller.
 The performance of the implementation is defined by the performance of the underlying filesystem functions and the implemented logic doesn't add any significant overhead.
 

--- a/ament_index_cpp/QUALITY_DECLARATION.md
+++ b/ament_index_cpp/QUALITY_DECLARATION.md
@@ -124,7 +124,7 @@ A description of how coverage statistics are summarized from this page, can be f
 An environment variable defines the prefix paths of such resource indices and the API has a time complexity of `O(n)` where `n` is the number of prefix paths.
 The time complexity to query information is either scaling linearly with the number of resource types or with the number of resources per type (depending on which dimension is requested).
 If the content of a specific resource is retrieved the time complexity is linear to the size of the content as is the memory usage in that case since the content is returned to the caller.
-The performance of the implementation is defined by the performance of the underlying filesystem functions and the implemented logic doesn't add any significant overhead.
+The runtime cost of the implementation is dominated by the runtime cost of the underlying filesystem API, and the implemented logic doesn't add any significant overhead.
 
 From a usage point of view it is also expected that the resource index is commonly only queried during startup and not at runtime of a production system.
 Therefore `ament_index_cpp` does not conduct explicit performance tests.

--- a/ament_index_cpp/QUALITY_DECLARATION.md
+++ b/ament_index_cpp/QUALITY_DECLARATION.md
@@ -121,7 +121,13 @@ A description of how coverage statistics are summarized from this page, can be f
 
 ### Performance [4.iv]
 
-`ament_index_cpp` does not conduct performance tests.
+An environment variable defines the prefix paths of such resource indices and the API has a time complexity of `O(n)` where `n` is the number of prefix paths.
+The time complexity to query information is either scaling lineraly with the number of resource types or with the number of resources per type (depending on which dimension is requested).
+If the content of a specific resource is retrieved the time complexity is linear to the size of the content as is the memory usage in that case since the content is returned to the caller.
+The performance of the implementation is defined by the performance of the underlying filesystem functions and the implemented logic doesn't add any significant overhead.
+
+From a usage point of view it is also expected that the resource index is commonly only queried during startup and not at runtime of a production system.
+Therefore `ament_index_cpp` does not conduct explicit performance tests.
 
 ### Linters and Static Analysis [4.v]
 

--- a/ament_index_python/QUALITY_DECLARATION.md
+++ b/ament_index_python/QUALITY_DECLARATION.md
@@ -119,7 +119,7 @@ Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linu
 ### Performance [4.iv]
 
 An environment variable defines the prefix paths of such resource indices and the API has a time complexity of `O(n)` where `n` is the number of prefix paths.
-The time complexity to query information is either scaling lineraly with the number of resource types or with the number of resources per type (depending on which dimension is requested).
+The time complexity to query information is either scaling linearly with the number of resource types or with the number of resources per type (depending on which dimension is requested).
 If the content of a specific resource is retrieved the time complexity is linear to the size of the content as is the memory usage in that case since the content is returned to the caller.
 The performance of the implementation is defined by the performance of the underlying filesystem functions and the implemented logic doesn't add any significant overhead.
 

--- a/ament_index_python/QUALITY_DECLARATION.md
+++ b/ament_index_python/QUALITY_DECLARATION.md
@@ -121,7 +121,7 @@ Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linu
 An environment variable defines the prefix paths of such resource indices and the API has a time complexity of `O(n)` where `n` is the number of prefix paths.
 The time complexity to query information is either scaling linearly with the number of resource types or with the number of resources per type (depending on which dimension is requested).
 If the content of a specific resource is retrieved the time complexity is linear to the size of the content as is the memory usage in that case since the content is returned to the caller.
-The performance of the implementation is defined by the performance of the underlying filesystem functions and the implemented logic doesn't add any significant overhead.
+The runtime cost of the implementation is dominated by the runtime cost of the underlying filesystem API, and the implemented logic doesn't add any significant overhead.
 
 From a usage point of view it is also expected that the resource index is commonly only queried during startup and not at runtime of a production system.
 Therefore `ament_index_python` does not conduct explicit performance tests.

--- a/ament_index_python/QUALITY_DECLARATION.md
+++ b/ament_index_python/QUALITY_DECLARATION.md
@@ -118,7 +118,13 @@ Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linu
 
 ### Performance [4.iv]
 
-`ament_index_python` does not conduct performance tests. It is not yet defined if this package requires performance testing and how addresses this topic.
+An environment variable defines the prefix paths of such resource indices and the API has a time complexity of `O(n)` where `n` is the number of prefix paths.
+The time complexity to query information is either scaling lineraly with the number of resource types or with the number of resources per type (depending on which dimension is requested).
+If the content of a specific resource is retrieved the time complexity is linear to the size of the content as is the memory usage in that case since the content is returned to the caller.
+The performance of the implementation is defined by the performance of the underlying filesystem functions and the implemented logic doesn't add any significant overhead.
+
+From a usage point of view it is also expected that the resource index is commonly only queried during startup and not at runtime of a production system.
+Therefore `ament_index_python` does not conduct explicit performance tests.
 
 ### Linters and Static Analysis [4.v]
 


### PR DESCRIPTION
This is a first draft for a rational why performance tests aren't necessary for `ament_index_*` packages.