### PR TITLE
Fail lookups on invalid resource names

### DIFF
--- a/ament_index_python/ament_index_python/__init__.py
+++ b/ament_index_python/ament_index_python/__init__.py
@@ -21,8 +21,8 @@ from .resources import get_resource
 from .resources import get_resource_types
 from .resources import get_resources
 from .resources import has_resource
-from .resources import InvalidResourceTypeNameError
 from .resources import InvalidResourceNameError
+from .resources import InvalidResourceTypeNameError
 from .search_paths import get_search_paths
 
 __all__ = [

--- a/ament_index_python/ament_index_python/__init__.py
+++ b/ament_index_python/ament_index_python/__init__.py
@@ -33,7 +33,7 @@ __all__ = [
     'get_search_paths',
     'get_resource_types',
     'has_resource',
-    'InvalidResourceNameError'
+    'InvalidResourceNameError',
     'PackageNotFoundError',
     'RESOURCE_INDEX_SUBFOLDER',
 ]

--- a/ament_index_python/ament_index_python/__init__.py
+++ b/ament_index_python/ament_index_python/__init__.py
@@ -21,6 +21,7 @@ from .resources import get_resource
 from .resources import get_resource_types
 from .resources import get_resources
 from .resources import has_resource
+from .resources import InvalidResourceTypeNameError
 from .resources import InvalidResourceNameError
 from .search_paths import get_search_paths
 
@@ -33,6 +34,7 @@ __all__ = [
     'get_search_paths',
     'get_resource_types',
     'has_resource',
+    'InvalidResourceTypeNameError',
     'InvalidResourceNameError',
     'PackageNotFoundError',
     'RESOURCE_INDEX_SUBFOLDER',

--- a/ament_index_python/ament_index_python/__init__.py
+++ b/ament_index_python/ament_index_python/__init__.py
@@ -21,6 +21,7 @@ from .resources import get_resource
 from .resources import get_resource_types
 from .resources import get_resources
 from .resources import has_resource
+from .resources import InvalidResourceNameError
 from .search_paths import get_search_paths
 
 __all__ = [

--- a/ament_index_python/ament_index_python/__init__.py
+++ b/ament_index_python/ament_index_python/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
     'get_search_paths',
     'get_resource_types',
     'has_resource',
+    'InvalidResourceNameError'
     'PackageNotFoundError',
     'RESOURCE_INDEX_SUBFOLDER',
 ]

--- a/ament_index_python/ament_index_python/packages.py
+++ b/ament_index_python/ament_index_python/packages.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import re
 
 from .resources import get_resource
 from .resources import get_resources
@@ -44,7 +45,11 @@ def get_package_prefix(package_name):
     :param str package_name: name of the package to locate
     :returns: installation prefix of the package
     :raises: :exc:`PackageNotFoundError` if the package is not found
+    :raises: :exc:`ValueError` if the package name is invalid
     """
+    if re.fullmatch('[a-z][a-z0-9_]+', package_name, re.ASCII) is None:
+        raise ValueError(
+            "'{}' is not a valid package name".format(package_name))
     try:
         content, package_prefix = get_resource('packages', package_name)
     except LookupError:
@@ -65,5 +70,6 @@ def get_package_share_directory(package_name):
     :param str package_name: name of the package to locate
     :returns: share directory of the package
     :raises: :exc:`PackageNotFoundError` if the package is not found
+    :raises: :exc:`ValueError` if the package name is invalid
     """
     return os.path.join(get_package_prefix(package_name), 'share', package_name)

--- a/ament_index_python/ament_index_python/packages.py
+++ b/ament_index_python/ament_index_python/packages.py
@@ -47,7 +47,9 @@ def get_package_prefix(package_name):
     :raises: :exc:`PackageNotFoundError` if the package is not found
     :raises: :exc:`ValueError` if the package name is invalid
     """
-    if re.fullmatch('[a-z][a-z0-9_]+', package_name, re.ASCII) is None:
+    # This regex checks for a valid package name as defined by REP-127 including the recommended
+    #  exemptions. See https://ros.org/reps/rep-0127.html#name
+    if re.fullmatch('[a-zA-Z0-9][a-zA-Z0-9_-]+', package_name, re.ASCII) is None:
         raise ValueError(
             "'{}' is not a valid package name".format(package_name))
     try:

--- a/ament_index_python/ament_index_python/resources.py
+++ b/ament_index_python/ament_index_python/resources.py
@@ -19,14 +19,16 @@ from .constants import RESOURCE_INDEX_SUBFOLDER
 from .search_paths import get_search_paths
 
 
+class InvalidResourceTypeNameError(ValueError):
+    pass
+
+
 class InvalidResourceNameError(ValueError):
     pass
 
 
 def name_is_invalid(resource_name):
-    if ('/' in resource_name) or ('\\' in resource_name):
-        return True
-    return False
+    return ('/' in resource_name) or ('\\' in resource_name)
 
 
 def get_resource(resource_type, resource_name):
@@ -41,9 +43,14 @@ def get_resource(resource_type, resource_name):
     :raises: :exc:`EnvironmentError`
     :raises: :exc:`OSError`
     :raises: :exc:`LookupError`
+    :raises: :exc:`InvalidResourceTypeNameError`
+    :raises: :exc:`InvalidResourceNameError`
     """
     assert resource_type, 'The resource type must not be empty'
     assert resource_name, 'The resource name must not be empty'
+    if name_is_invalid(resource_type):
+        raise InvalidResourceTypeNameError(
+            "Resource type '%s' is invalid" % resource_type)
     if name_is_invalid(resource_name):
         raise InvalidResourceNameError(
             "Resource name '%s' is invalid" % resource_name)
@@ -70,8 +77,12 @@ def get_resources(resource_type):
     :type resource_type: str
     :returns: dict of resource names to the prefix path they are in
     :raises: :exc:`EnvironmentError`
+    :raises: :exc:`InvalidResourceTypeNameError`
     """
     assert resource_type, 'The resource type must not be empty'
+    if name_is_invalid(resource_type):
+        raise InvalidResourceTypeNameError(
+            "Resource type '%s' is invalid" % resource_type)
     resources = {}
     for path in get_search_paths():
         resource_path = os.path.join(path, RESOURCE_INDEX_SUBFOLDER, resource_type)
@@ -116,9 +127,14 @@ def has_resource(resource_type, resource_name):
     :type resource_name: str
     :returns: The prefix path if the resource exists, False otherwise
     :raises: :exc:`EnvironmentError`
+    :raises: :exc:`InvalidResourceTypeNameError`
+    :raises: :exc:`InvalidResourceNameError`
     """
     assert resource_type, 'The resource type must not be empty'
     assert resource_name, 'The resource name must not be empty'
+    if name_is_invalid(resource_type):
+        raise InvalidResourceTypeNameError(
+            "Resource type '%s' is invalid" % resource_type)
     if name_is_invalid(resource_name):
         raise InvalidResourceNameError(
             "Resource name '%s' is invalid" % resource_name)

--- a/ament_index_python/ament_index_python/resources.py
+++ b/ament_index_python/ament_index_python/resources.py
@@ -18,13 +18,16 @@ from .constants import RESOURCE_INDEX_SUBFOLDER
 
 from .search_paths import get_search_paths
 
+
 class InvalidResourceNameError(ValueError):
     pass
+
 
 def name_is_invalid(resource_name):
     if '/' in resource_name:
         return True
     return False
+
 
 def get_resource(resource_type, resource_name):
     """
@@ -43,7 +46,7 @@ def get_resource(resource_type, resource_name):
     assert resource_name, 'The resource name must not be empty'
     if name_is_invalid(resource_name):
         raise InvalidResourceNameError(
-            "Resource name '%s' is invalid" % resource_name )
+            "Resource name '%s' is invalid" % resource_name)
     for path in get_search_paths():
         resource_path = os.path.join(path, RESOURCE_INDEX_SUBFOLDER, resource_type, resource_name)
         if os.path.isfile(resource_path):
@@ -118,7 +121,7 @@ def has_resource(resource_type, resource_name):
     assert resource_name, 'The resource name must not be empty'
     if name_is_invalid(resource_name):
         raise InvalidResourceNameError(
-            "Resource name '%s' is invalid" % resource_name )
+            "Resource name '%s' is invalid" % resource_name)
     for path in get_search_paths():
         resource_path = os.path.join(path, RESOURCE_INDEX_SUBFOLDER, resource_type, resource_name)
         if os.path.isfile(resource_path):

--- a/ament_index_python/ament_index_python/resources.py
+++ b/ament_index_python/ament_index_python/resources.py
@@ -31,9 +31,11 @@ class InvalidResourceNameError(ValueError):
     pass
 
 
-def name_is_invalid(resource_name):
+def _name_is_invalid(resource_name):
     """
     Get the whether a resource name or a resource type name is invalid.
+
+    This is not considered public API.
 
     A name is considered invalid if it contains any path separators. The index represents resources
     as files and resource types as folders so allowing path separators causes issues.
@@ -64,10 +66,10 @@ def get_resource(resource_type, resource_name):
     """
     assert resource_type, 'The resource type must not be empty'
     assert resource_name, 'The resource name must not be empty'
-    if name_is_invalid(resource_type):
+    if _name_is_invalid(resource_type):
         raise InvalidResourceTypeNameError(
             "Resource type '%s' is invalid" % resource_type)
-    if name_is_invalid(resource_name):
+    if _name_is_invalid(resource_name):
         raise InvalidResourceNameError(
             "Resource name '%s' is invalid" % resource_name)
     for path in get_search_paths():
@@ -96,7 +98,7 @@ def get_resources(resource_type):
     :raises: :exc:`InvalidResourceTypeNameError`
     """
     assert resource_type, 'The resource type must not be empty'
-    if name_is_invalid(resource_type):
+    if _name_is_invalid(resource_type):
         raise InvalidResourceTypeNameError(
             "Resource type '%s' is invalid" % resource_type)
     resources = {}
@@ -148,10 +150,10 @@ def has_resource(resource_type, resource_name):
     """
     assert resource_type, 'The resource type must not be empty'
     assert resource_name, 'The resource name must not be empty'
-    if name_is_invalid(resource_type):
+    if _name_is_invalid(resource_type):
         raise InvalidResourceTypeNameError(
             "Resource type '%s' is invalid" % resource_type)
-    if name_is_invalid(resource_name):
+    if _name_is_invalid(resource_name):
         raise InvalidResourceNameError(
             "Resource name '%s' is invalid" % resource_name)
     for path in get_search_paths():

--- a/ament_index_python/ament_index_python/resources.py
+++ b/ament_index_python/ament_index_python/resources.py
@@ -24,7 +24,7 @@ class InvalidResourceNameError(ValueError):
 
 
 def name_is_invalid(resource_name):
-    if '/' in resource_name:
+    if ('/' in resource_name) or ('\\' in resource_name):
         return True
     return False
 

--- a/ament_index_python/ament_index_python/resources.py
+++ b/ament_index_python/ament_index_python/resources.py
@@ -18,6 +18,13 @@ from .constants import RESOURCE_INDEX_SUBFOLDER
 
 from .search_paths import get_search_paths
 
+class InvalidResourceNameError(ValueError):
+    pass
+
+def name_is_invalid(resource_name):
+    if '/' in resource_name:
+        return True
+    return False
 
 def get_resource(resource_type, resource_name):
     """
@@ -34,6 +41,9 @@ def get_resource(resource_type, resource_name):
     """
     assert resource_type, 'The resource type must not be empty'
     assert resource_name, 'The resource name must not be empty'
+    if name_is_invalid(resource_name):
+        raise InvalidResourceNameError(
+            "Resource name '%s' is invalid" % resource_name )
     for path in get_search_paths():
         resource_path = os.path.join(path, RESOURCE_INDEX_SUBFOLDER, resource_type, resource_name)
         if os.path.isfile(resource_path):
@@ -106,6 +116,9 @@ def has_resource(resource_type, resource_name):
     """
     assert resource_type, 'The resource type must not be empty'
     assert resource_name, 'The resource name must not be empty'
+    if name_is_invalid(resource_name):
+        raise InvalidResourceNameError(
+            "Resource name '%s' is invalid" % resource_name )
     for path in get_search_paths():
         resource_path = os.path.join(path, RESOURCE_INDEX_SUBFOLDER, resource_type, resource_name)
         if os.path.isfile(resource_path):

--- a/ament_index_python/ament_index_python/resources.py
+++ b/ament_index_python/ament_index_python/resources.py
@@ -20,14 +20,30 @@ from .search_paths import get_search_paths
 
 
 class InvalidResourceTypeNameError(ValueError):
+    """Raised when a resource type name is invalid."""
+
     pass
 
 
 class InvalidResourceNameError(ValueError):
+    """Raised when a resource name is invalid."""
+
     pass
 
 
 def name_is_invalid(resource_name):
+    """
+    Get the whether a resource name or a resource type name is invalid.
+
+    A name is considered invalid if it contains any path separators. The index represents resources
+    as files and resource types as folders so allowing path separators causes issues.
+
+    For a more complete discussion, see: https://github.com/ament/ament_index/pull/69
+
+    :param resource_name: the name of the resource or resource type
+    :type resource_name: str
+    :returns: True or False
+    """
     return ('/' in resource_name) or ('\\' in resource_name)
 
 

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -193,7 +193,7 @@ def test_get_package_prefix():
     assert issubclass(PackageNotFoundError, KeyError)
 
     invalid_package_names = [
-        '_package', 'packageA', 'package a', 'package/a', '0package', 'package.a']
+        '_package', 'package a', 'package/a', 'package.a']
     for name in invalid_package_names:
         with pytest.raises(ValueError):
             get_package_prefix(name)

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -24,6 +24,7 @@ from ament_index_python import get_resources
 from ament_index_python import get_search_paths
 from ament_index_python import has_resource
 from ament_index_python import PackageNotFoundError
+from ament_index_python import InvalidResourceTypeNameError
 from ament_index_python import InvalidResourceNameError
 from ament_index_python.cli import main
 from ament_index_python.cli import resource_name_completer
@@ -65,6 +66,25 @@ def test_unknown_resources():
     set_ament_prefix_path(['prefix1'])
     resources = get_resources('unknown_resource_type')
     assert len(resources) == 0, 'Expected no resources'
+
+
+def test_invalid_resources():
+    set_ament_prefix_path(['prefix1'])
+
+    invalid_resource_type_names = [
+        '/invalid/name', 'invalid/name', '\\invalid\\name', 'invalid\\name']
+
+    for name in invalid_resource_type_names:
+        with pytest.raises(InvalidResourceTypeNameError):
+            resources = get_resources(name)
+            assert len(resources) == 0, 'Expected no resources'
+
+        with pytest.raises(InvalidResourceTypeNameError):
+            exists = has_resource(name, "example_resource")
+            assert not exists, 'Resource should not exist'
+
+        with pytest.raises(InvalidResourceTypeNameError):
+            get_resource(name, "example_resource")
 
 
 def test_resources():

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -157,11 +157,15 @@ def test_get_package_prefix():
         get_package_prefix('does_not_exist')
     assert issubclass(PackageNotFoundError, KeyError)
 
-    with pytest.raises(InvalidResourceNameError):
+    invalid_package_names = ['_package','packageA','package a','package/a','0package','package.a']
+    for name in invalid_package_names:
+        with pytest.raises(ValueError):
+            get_package_prefix(name)
+
+    with pytest.raises(ValueError):
         # An absolue path is not a valid package name
         extant_absolute_path = os.path.abspath(__file__)
         get_package_prefix(extant_absolute_path)
-    assert issubclass(InvalidResourceNameError, ValueError)
 
 
 def test_get_package_share_directory():
@@ -183,6 +187,9 @@ def test_get_package_share_directory():
 
     with pytest.raises(PackageNotFoundError):
         get_package_share_directory('does_not_exist')
+
+    with pytest.raises(ValueError):
+        get_package_share_directory('/invalid/package/name')
 
 
 def test_get_resource_types():

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -97,6 +97,21 @@ def test_unknown_resource():
         get_resource('resource_type4', 'bar')
 
 
+def test_invalid_resource_names():
+    set_ament_prefix_path(['prefix1'])
+
+    invalid_resource_names = [
+        '/invalid/name', 'invalid/name', '\\invalid\\name', 'invalid\\name']
+
+    for name in invalid_resource_names:
+        with pytest.raises(InvalidResourceNameError):
+            exists = has_resource('resource_type4', name)
+            assert not exists, 'Resource should not exist'
+
+        with pytest.raises(InvalidResourceNameError):
+            get_resource('resource_type4', name)
+
+
 def test_absolute_path_resource():
     extant_absolute_path = os.path.abspath(__file__)
 

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -23,9 +23,9 @@ from ament_index_python import get_resource_types
 from ament_index_python import get_resources
 from ament_index_python import get_search_paths
 from ament_index_python import has_resource
-from ament_index_python import PackageNotFoundError
-from ament_index_python import InvalidResourceTypeNameError
 from ament_index_python import InvalidResourceNameError
+from ament_index_python import InvalidResourceTypeNameError
+from ament_index_python import PackageNotFoundError
 from ament_index_python.cli import main
 from ament_index_python.cli import resource_name_completer
 from ament_index_python.cli import resource_type_completer

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -157,7 +157,8 @@ def test_get_package_prefix():
         get_package_prefix('does_not_exist')
     assert issubclass(PackageNotFoundError, KeyError)
 
-    invalid_package_names = ['_package','packageA','package a','package/a','0package','package.a']
+    invalid_package_names = [
+        '_package', 'packageA', 'package a', 'package/a', '0package', 'package.a']
     for name in invalid_package_names:
         with pytest.raises(ValueError):
             get_package_prefix(name)

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -24,6 +24,7 @@ from ament_index_python import get_resources
 from ament_index_python import get_search_paths
 from ament_index_python import has_resource
 from ament_index_python import PackageNotFoundError
+from ament_index_python import InvalidResourceNameError
 from ament_index_python.cli import main
 from ament_index_python.cli import resource_name_completer
 from ament_index_python.cli import resource_type_completer
@@ -96,6 +97,17 @@ def test_unknown_resource():
         get_resource('resource_type4', 'bar')
 
 
+def test_absolute_path_resource():
+    extant_absolute_path = os.path.abspath(__file__)
+
+    set_ament_prefix_path(['prefix1'])
+    with pytest.raises(InvalidResourceNameError):
+        exists = has_resource('resource_type4', str(extant_absolute_path))
+        assert not exists, 'Resource should not exist'
+
+    with pytest.raises(InvalidResourceNameError):
+        get_resource('resource_type4', str(extant_absolute_path))
+
 def test_resource():
     set_ament_prefix_path(['prefix1'])
     exists = has_resource('resource_type4', 'foo')
@@ -143,6 +155,12 @@ def test_get_package_prefix():
     with pytest.raises(PackageNotFoundError):
         get_package_prefix('does_not_exist')
     assert issubclass(PackageNotFoundError, KeyError)
+
+    with pytest.raises(InvalidResourceNameError):
+        # An absolue path is not a valid package name
+        extant_absolute_path = os.path.abspath(__file__)
+        get_package_prefix(extant_absolute_path)
+    assert issubclass(InvalidResourceNameError, ValueError)
 
 
 def test_get_package_share_directory():

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -80,11 +80,11 @@ def test_invalid_resources():
             assert len(resources) == 0, 'Expected no resources'
 
         with pytest.raises(InvalidResourceTypeNameError):
-            exists = has_resource(name, "example_resource")
+            exists = has_resource(name, 'example_resource')
             assert not exists, 'Resource should not exist'
 
         with pytest.raises(InvalidResourceTypeNameError):
-            get_resource(name, "example_resource")
+            get_resource(name, 'example_resource')
 
 
 def test_resources():

--- a/ament_index_python/test/test_ament_index_python.py
+++ b/ament_index_python/test/test_ament_index_python.py
@@ -108,6 +108,7 @@ def test_absolute_path_resource():
     with pytest.raises(InvalidResourceNameError):
         get_resource('resource_type4', str(extant_absolute_path))
 
+
 def test_resource():
     set_ament_prefix_path(['prefix1'])
     exists = has_resource('resource_type4', 'foo')


### PR DESCRIPTION
Depends on https://github.com/ros2/ros2cli/pull/643

---

This was found through ros2launch, where attempting to provide an absolute path to a launch file, along with launch arguments, resulted in failure. This was because ros2launch was passing the absolute path to `get_package_prefix()` in attempting to see if it was a package.

If a valid absolute path was passed to `get_package_prefix()` as the package name, a `PackageNotFoundError` was **not** raised and instead the first path from `get_search_paths()` was returned.

This resulted from the behaviour of `get_resource()`: if a valid absolute path was passed to `get_resource()` as the resource name, the contents of that absolute path was returned along with the first path from `get_search_paths()` as the path.

This PR adds an `InvalidResourceNameError` which is raised when the resource name argument contains a `/`. This catches the absolute path case as well as cases that may result from relative paths. I couldn't find any hard requirements on resource names other than a suggestion [here](https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md#marker-files) that they should conform to [REP 127](https://www.ros.org/reps/rep-0127.html#name) suggestions on naming, which are now captured in [REP 144](https://www.ros.org/reps/rep-0144.html). If stricter restrictions on resource names are defined, these can be added to the `name_is_invalid()` function added here.

I'm unsure if this is a good fit for here or the problem is better off being addressed in ros2launch, where input to `get_package_prefix()` could be sanitised. Even if changed here, a fix in ros2launch will be needed but the error message should now be a little clearer.