### PR TITLE
Remove ament_export_include_directories and ament_export_libraries

### DIFF
--- a/ament_index_cpp/CMakeLists.txt
+++ b/ament_index_cpp/CMakeLists.txt
@@ -33,8 +33,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
 
-ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 if(BUILD_TESTING)


### PR DESCRIPTION
Part of https://github.com/ament/ament_cmake/issues/365

Remove `ament_export_include_directories()` and `ament_export_libraries()` because they're redundant with `ament_export_targets()`.