### PR TITLE
only append search paths on first PackageNotFound

### DIFF
--- a/ament_index_cpp/src/get_package_prefix.cpp
+++ b/ament_index_cpp/src/get_package_prefix.cpp
@@ -23,11 +23,20 @@
 namespace ament_index_cpp
 {
 
+static size_t package_not_found_count = 0;
+
 static
 std::string
 format_package_not_found_error_message(const std::string & package_name)
 {
-  std::string message = "package '" + package_name + "' not found, searching: [";
+  std::string message = "package '" + package_name + "' not found";
+
+  // Don't need to print out the package paths more than once
+  if (package_not_found_count++ > 0) {
+    return message;
+  }
+
+  message += ", searching: [";
   auto search_paths = get_search_paths();
   for (const auto & path : search_paths) {
     message += path + ", ";


### PR DESCRIPTION
I played a ros bag and got more than ten package not found warnings which took up a lot of lines of terminal output:

```
Ignoring a topic '/fmu/out/vehicle_status', reason: package 'px4_msgs' not found, searching: [/home/lucasw/ros/ros2_rolling/install/rqt_bag_plugins, /home/lucasw/ros/ros2_rolling/install/rosbag2, /home/lucasw/ros/ros2_rolling/install/rosbag2_storage_default_plugins, ...
```

Only the first instance was useful if I were to inspect the path output (though even printing out one complete set takes many lines of wrapped output), so limiting that here, it prints the first one fully then is more concise:

```
...
/home/lucasw/ros/ros2_rolling/install/ament_flake8, /home/lucasw/ros/ros2_rolling/install/ament_copyright, /home/lucasw/ros/ros2_rolling/install/ament_lint, /home/lucasw/ros/ros2_rolling/install/ament_index_python, /home/lucasw/ros/ros2_rolling/install/ament_index_cpp, /home/lucasw/ros/ros2_rolling/install/ament_cpplint, /home/lucasw/ros/ros2_rolling/install/ament_cppcheck, /home/lucasw/ros/ros2_rolling/install/ament_clang_tidy, /home/lucasw/ros/ros2_rolling/install/ament_clang_format].
[WARN] [1702825347.983349419] [rosbag2_player]: Ignoring a topic '/fmu/out/vehicle_odometry', reason: package 'px4_msgs' not found.
[WARN] [1702825347.983974247] [rosbag2_player]: Ignoring a topic '/fmu/out/vehicle_local_position', reason: package 'px4_msgs' not found.
[WARN] [1702825347.984591679] [rosbag2_player]: Ignoring a topic '/fmu/out/failsafe_flags', reason: package 'px4_msgs' not found.
[WARN] [1702825347.985206149] [rosbag2_player]: Ignoring a topic '/fmu/out/timesync_status', reason: package 'px4_msgs' not found.
[WARN] [1702825347.985826904] [rosbag2_player]: Ignoring a topic '/fmu/out/vehicle_control_mode', reason: package 'px4_msgs' not found.
```

