### PR TITLE
Add type annotations to python files.

### DIFF
--- a/ament_index_python/ament_index_python/cli.py
+++ b/ament_index_python/ament_index_python/cli.py
@@ -14,13 +14,13 @@
 
 import argparse
 import sys
+from typing import Any, Dict, Generator, List, Tuple, Optional, Union
 
-from ament_index_python.resources import get_resource
-from ament_index_python.resources import get_resource_types
-from ament_index_python.resources import get_resources
+from ament_index_python.resources import (get_resource, get_resource_types,
+                                          get_resources)
 
 
-def main(argv=sys.argv[1:]):
+def main(argv: List[str] = sys.argv[1:]) -> Optional[str]:
     parser = argparse.ArgumentParser(
         description='Query the ament resource index.')
     arg = parser.add_argument(
@@ -44,13 +44,13 @@ def main(argv=sys.argv[1:]):
     if args.resource_type is None:
         for resource_type in sorted(get_resource_types()):
             print(resource_type)
-        return
+        return None
 
     if args.resource_name is None:
         resources = get_resources(args.resource_type)
         for resource_name in sorted(resources.keys()):
-            print(resource_name + '\t' + resources[resource_name])
-        return
+            print(f'{resource_name}\t{resources[resource_name]}')
+        return None
 
     try:
         content, path = get_resource(args.resource_type, args.resource_name)
@@ -61,13 +61,17 @@ def main(argv=sys.argv[1:]):
         print('<<<')
         print(content)
         print('>>>')
+    
+    return None
 
 
-def resource_type_completer(prefix, **kwargs):
+def resource_type_completer(prefix: Union[str, Tuple[str, ...]], **kwarg: Dict[str, Any]) -> Generator[str, None, None]:
     return (t for t in get_resource_types() if t.startswith(prefix))
 
 
-def resource_name_completer(prefix, parsed_args, **kwargs):
+def resource_name_completer(prefix: Union[str, Tuple[str, ...]],
+                            parsed_args: argparse.Namespace,
+                            **kwargs: Dict[str, Any]) -> Union[Generator[str, None, None], List[str]]:
     resource_type = getattr(parsed_args, 'resource_type', None)
     if not resource_type:
         return []

--- a/ament_index_python/ament_index_python/cli.py
+++ b/ament_index_python/ament_index_python/cli.py
@@ -14,7 +14,7 @@
 
 import argparse
 import sys
-from typing import Any, Dict, Generator, List, Tuple, Optional, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 from ament_index_python.resources import get_resource
 from ament_index_python.resources import get_resource_types
@@ -62,17 +62,19 @@ def main(argv: List[str] = sys.argv[1:]) -> Optional[str]:
         print('<<<')
         print(content)
         print('>>>')
-    
+
     return None
 
 
-def resource_type_completer(prefix: Union[str, Tuple[str, ...]], **kwarg: Dict[str, Any]) -> Generator[str, None, None]:
+def resource_type_completer(prefix: Union[str, Tuple[str, ...]],
+                            **kwarg: Dict[str, Any]) -> Generator[str, None, None]:
     return (t for t in get_resource_types() if t.startswith(prefix))
 
 
 def resource_name_completer(prefix: Union[str, Tuple[str, ...]],
                             parsed_args: argparse.Namespace,
-                            **kwargs: Dict[str, Any]) -> Union[Generator[str, None, None], List[str]]:
+                            **kwargs: Dict[str, Any]) -> Union[Generator[str, None, None],
+                                                               List[str]]:
     resource_type = getattr(parsed_args, 'resource_type', None)
     if not resource_type:
         return []

--- a/ament_index_python/ament_index_python/cli.py
+++ b/ament_index_python/ament_index_python/cli.py
@@ -16,8 +16,9 @@ import argparse
 import sys
 from typing import Any, Dict, Generator, List, Tuple, Optional, Union
 
-from ament_index_python.resources import (get_resource, get_resource_types,
-                                          get_resources)
+from ament_index_python.resources import get_resource
+from ament_index_python.resources import get_resource_types
+from ament_index_python.resources import get_resources
 
 
 def main(argv: List[str] = sys.argv[1:]) -> Optional[str]:

--- a/ament_index_python/ament_index_python/packages.py
+++ b/ament_index_python/ament_index_python/packages.py
@@ -23,7 +23,7 @@ from .resources import get_resource
 from .resources import get_resources
 from .search_paths import get_search_paths
 
-
+ 
 class PackageNotFoundError(KeyError):
     pass
 

--- a/ament_index_python/ament_index_python/packages.py
+++ b/ament_index_python/ament_index_python/packages.py
@@ -17,6 +17,8 @@ import pathlib
 import re
 import warnings
 
+from typing import Dict, Union
+
 from .resources import get_resource
 from .resources import get_resources
 from .search_paths import get_search_paths
@@ -26,7 +28,7 @@ class PackageNotFoundError(KeyError):
     pass
 
 
-def get_packages_with_prefixes():
+def get_packages_with_prefixes() -> Dict[str, Union[str, os.PathLike[str]]]:
     """
     Return a dict of package names to the prefixes in which they are found.
 
@@ -36,7 +38,7 @@ def get_packages_with_prefixes():
     return get_resources('packages')
 
 
-def get_package_prefix(package_name):
+def get_package_prefix(package_name: str) -> Union[str, os.PathLike[str]]:
     """
     Return the installation prefix directory of the given package.
 
@@ -62,7 +64,7 @@ def get_package_prefix(package_name):
     return package_prefix
 
 
-def get_package_share_directory(package_name, print_warning=True):
+def get_package_share_directory(package_name: str, print_warning: bool = True) -> str:
     """
     Return the share directory of the given package.
 
@@ -83,7 +85,7 @@ def get_package_share_directory(package_name, print_warning=True):
     return path
 
 
-def get_package_share_path(package_name, print_warning=True):
+def get_package_share_path(package_name: str, print_warning: bool = True) -> pathlib.Path:
     """
     Return the share directory of the given package as a pathlib.Path.
 

--- a/ament_index_python/ament_index_python/packages.py
+++ b/ament_index_python/ament_index_python/packages.py
@@ -23,7 +23,7 @@ from .resources import get_resource
 from .resources import get_resources
 from .search_paths import get_search_paths
 
- 
+
 class PackageNotFoundError(KeyError):
     pass
 

--- a/ament_index_python/ament_index_python/packages.py
+++ b/ament_index_python/ament_index_python/packages.py
@@ -17,7 +17,7 @@ import pathlib
 import re
 import warnings
 
-from typing import Dict, Union
+from typing import Dict
 
 from .resources import get_resource
 from .resources import get_resources
@@ -38,7 +38,7 @@ def get_packages_with_prefixes() -> Dict[str, str]:
     return get_resources('packages')
 
 
-def get_package_prefix(package_name: str) -> Union[str, os.PathLike[str]]:
+def get_package_prefix(package_name: str) -> str:
     """
     Return the installation prefix directory of the given package.
 

--- a/ament_index_python/ament_index_python/packages.py
+++ b/ament_index_python/ament_index_python/packages.py
@@ -28,7 +28,7 @@ class PackageNotFoundError(KeyError):
     pass
 
 
-def get_packages_with_prefixes() -> Dict[str, Union[str, os.PathLike[str]]]:
+def get_packages_with_prefixes() -> Dict[str, str]:
     """
     Return a dict of package names to the prefixes in which they are found.
 

--- a/ament_index_python/ament_index_python/packages.py
+++ b/ament_index_python/ament_index_python/packages.py
@@ -15,9 +15,9 @@
 import os
 import pathlib
 import re
+from typing import Dict
 import warnings
 
-from typing import Dict
 
 from .resources import get_resource
 from .resources import get_resources

--- a/ament_index_python/ament_index_python/resources.py
+++ b/ament_index_python/ament_index_python/resources.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 
 import os
+import sys
 from typing import Dict, Literal, Tuple, Union
+
+if sys.version_info >= (3, 10):
+    Set = set
+else:
+    from typing import Set
 
 from .constants import RESOURCE_INDEX_SUBFOLDER
 from .search_paths import get_search_paths
@@ -115,7 +121,7 @@ def get_resources(resource_type: str) -> Dict[str, str]:
     return resources
 
 
-def get_resource_types() -> set[str]:
+def get_resource_types() -> Set[str]:
     """
     Get the resource types.
 

--- a/ament_index_python/ament_index_python/resources.py
+++ b/ament_index_python/ament_index_python/resources.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from typing import Dict, Union, Literal, Tuple
 
 from .constants import RESOURCE_INDEX_SUBFOLDER
 
@@ -22,16 +23,12 @@ from .search_paths import get_search_paths
 class InvalidResourceTypeNameError(ValueError):
     """Raised when a resource type name is invalid."""
 
-    pass
-
 
 class InvalidResourceNameError(ValueError):
     """Raised when a resource name is invalid."""
 
-    pass
 
-
-def _name_is_invalid(resource_name):
+def _name_is_invalid(resource_name: str) -> bool:
     """
     Get the whether a resource name or a resource type name is invalid.
 
@@ -49,7 +46,7 @@ def _name_is_invalid(resource_name):
     return ('/' in resource_name) or ('\\' in resource_name)
 
 
-def get_resource(resource_type, resource_name):
+def get_resource(resource_type: str, resource_name: str) -> Tuple[str, Union[str, os.PathLike[str]]]:
     """
     Get the content of a specific resource and its prefix path.
 
@@ -87,7 +84,7 @@ def get_resource(resource_type, resource_name):
         "Could not find the resource '%s' of type '%s'" % (resource_name, resource_type))
 
 
-def get_resources(resource_type):
+def get_resources(resource_type: str) -> Dict[str, Union[str, os.PathLike[str]]]:
     """
     Get the resource names of all resources of the specified type.
 
@@ -115,7 +112,7 @@ def get_resources(resource_type):
     return resources
 
 
-def get_resource_types():
+def get_resource_types() -> set[str]:
     """
     Get the resource types.
 
@@ -135,7 +132,7 @@ def get_resource_types():
     return resource_types
 
 
-def has_resource(resource_type, resource_name):
+def has_resource(resource_type: str, resource_name: str) -> Union[str, os.PathLike[str], Literal[False]]:
     """
     Check if a specific resource exists.
 

--- a/ament_index_python/ament_index_python/resources.py
+++ b/ament_index_python/ament_index_python/resources.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from typing import Dict, Union, Literal, Tuple
+from typing import Dict, Literal, Tuple, Union
 
 from .constants import RESOURCE_INDEX_SUBFOLDER
 

--- a/ament_index_python/ament_index_python/resources.py
+++ b/ament_index_python/ament_index_python/resources.py
@@ -50,7 +50,7 @@ def _name_is_invalid(resource_name: str) -> bool:
     return ('/' in resource_name) or ('\\' in resource_name)
 
 
-def get_resource(resource_type: str, resource_name: str) -> Tuple[str, Union[str, os.PathLike[str]]]:
+def get_resource(resource_type: str, resource_name: str) -> Tuple[str, str]:
     """
     Get the content of a specific resource and its prefix path.
 
@@ -136,7 +136,7 @@ def get_resource_types() -> set[str]:
     return resource_types
 
 
-def has_resource(resource_type: str, resource_name: str) -> Union[str, os.PathLike[str], Literal[False]]:
+def has_resource(resource_type: str, resource_name: str) -> Union[str, Literal[False]]:
     """
     Check if a specific resource exists.
 

--- a/ament_index_python/ament_index_python/resources.py
+++ b/ament_index_python/ament_index_python/resources.py
@@ -16,7 +16,6 @@ import os
 from typing import Dict, Literal, Tuple, Union
 
 from .constants import RESOURCE_INDEX_SUBFOLDER
-
 from .search_paths import get_search_paths
 
 

--- a/ament_index_python/ament_index_python/resources.py
+++ b/ament_index_python/ament_index_python/resources.py
@@ -23,9 +23,13 @@ from .search_paths import get_search_paths
 class InvalidResourceTypeNameError(ValueError):
     """Raised when a resource type name is invalid."""
 
+    pass
+
 
 class InvalidResourceNameError(ValueError):
     """Raised when a resource name is invalid."""
+
+    pass
 
 
 def _name_is_invalid(resource_name: str) -> bool:
@@ -84,7 +88,7 @@ def get_resource(resource_type: str, resource_name: str) -> Tuple[str, Union[str
         "Could not find the resource '%s' of type '%s'" % (resource_name, resource_type))
 
 
-def get_resources(resource_type: str) -> Dict[str, Union[str, os.PathLike[str]]]:
+def get_resources(resource_type: str) -> Dict[str, str]:
     """
     Get the resource names of all resources of the specified type.
 

--- a/ament_index_python/ament_index_python/search_paths.py
+++ b/ament_index_python/ament_index_python/search_paths.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-
 from typing import List
 
 from .constants import AMENT_PREFIX_PATH_ENV_VAR

--- a/ament_index_python/ament_index_python/search_paths.py
+++ b/ament_index_python/ament_index_python/search_paths.py
@@ -14,12 +14,12 @@
 
 import os
 
-from typing import List, Union
+from typing import List
 
 from .constants import AMENT_PREFIX_PATH_ENV_VAR
 
 
-def get_search_paths() -> Union[List[str], List[os.PathLike[str]]]:
+def get_search_paths() -> List[str]:
     """
     Get the paths from the environment variable '{AMENT_PREFIX_PATH_ENV_VAR}'.
 

--- a/ament_index_python/ament_index_python/search_paths.py
+++ b/ament_index_python/ament_index_python/search_paths.py
@@ -14,10 +14,12 @@
 
 import os
 
+from typing import List, Union
+
 from .constants import AMENT_PREFIX_PATH_ENV_VAR
 
 
-def get_search_paths():
+def get_search_paths() -> Union[List[str], List[os.PathLike[str]]]:
     """
     Get the paths from the environment variable '{AMENT_PREFIX_PATH_ENV_VAR}'.
 


### PR DESCRIPTION
While adding type annotations to rclpy noticed some ament_index_python files were untyped.