### PR TITLE
Add test_xmllint to ament_index_python.

### DIFF
--- a/ament_index_python/package.xml
+++ b/ament_index_python/package.xml
@@ -19,6 +19,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_mypy</test_depend>
+  <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/ament_index_python/test/test_xmllint.py
+++ b/ament_index_python/test/test_xmllint.py
@@ -1,0 +1,23 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_xmllint.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.xmllint
+def test_xmllint():
+    rc = main(argv=[])
+    assert rc == 0, 'Found errors'


### PR DESCRIPTION
This is part of getting to https://github.com/ros2/ros2cli/issues/944 , in the sense that it fixes the core to actually do this. @sloretz FYI