### PR TITLE
Add `py.typed` to package_data

### DIFF
--- a/ament_index_python/setup.py
+++ b/ament_index_python/setup.py
@@ -16,6 +16,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',


### PR DESCRIPTION
Also removes extra `py.typed` found in `ament_index_python`. Left the correct one in `ament_index_python/ament_index_python`