### PR TITLE
Add autogenerated version header

### DIFF
--- a/ament_index_cpp/CMakeLists.txt
+++ b/ament_index_cpp/CMakeLists.txt
@@ -19,6 +19,7 @@ unless the library was explicitly added as a static library."
   ON)
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gen_version_h REQUIRED)
 
 add_library(${PROJECT_NAME}
   src/get_package_prefix.cpp
@@ -55,6 +56,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_package()
+ament_generate_version_header(ament_index_cpp)
 
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 

--- a/ament_index_cpp/package.xml
+++ b/ament_index_cpp/package.xml
@@ -16,6 +16,7 @@
   <author>Dirk Thomas</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_gen_version_h</buildtool_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
The changes introduced in #104 introduce [build failures in packages](https://build.ros2.org/job/Rdev__foxglove-sdk__ubuntu_noble_amd64/112/console) that depend on `ament_index` and have warnings escalated to errors using `-Werror`. Dependent packages could resolve this by using ament's autogenerated version macros and conditionally using the new API for `ament_index` version >= 1.13.0 This pull request enables generating those macros using `ament_cmake_gen_version_h`.