### PR TITLE
Use get_package_share_path just as python

### DIFF
--- a/ament_index_cpp/CMakeLists.txt
+++ b/ament_index_cpp/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(ament_cmake_gen_version_h REQUIRED)
 add_library(${PROJECT_NAME}
   src/get_package_prefix.cpp
   src/get_package_share_directory.cpp
+  src/get_package_share_path.cpp
   src/get_packages_with_prefixes.cpp
   src/get_resource.cpp
   src/get_resources.cpp

--- a/ament_index_cpp/include/ament_index_cpp/get_package_share_directory.hpp
+++ b/ament_index_cpp/include/ament_index_cpp/get_package_share_directory.hpp
@@ -29,21 +29,10 @@ namespace ament_index_cpp
  * \return share path of the package.
  * \throws PackageNotFoundError when the given package is not found.
  */
-[[deprecated("Use get_package_share_directory(..., std::filesystem::path) instead")]]
+[[deprecated("Use get_package_share_path(...) instead")]]
 AMENT_INDEX_CPP_PUBLIC
 std::string
 get_package_share_directory(const std::string & package_name);
-
-/// Return the share directory of the given package if found.
-/**
- * \param[in] package_name the name of the package to locate.
- * \param[out] path share path of the package.
- * \return
- * \throws PackageNotFoundError when the given package is not found.
- */
-AMENT_INDEX_CPP_PUBLIC
-void
-get_package_share_directory(const std::string & package_name, std::filesystem::path & path);
 
 }  // namespace ament_index_cpp
 

--- a/ament_index_cpp/include/ament_index_cpp/get_package_share_directory.hpp
+++ b/ament_index_cpp/include/ament_index_cpp/get_package_share_directory.hpp
@@ -34,6 +34,18 @@ AMENT_INDEX_CPP_PUBLIC
 std::string
 get_package_share_directory(const std::string & package_name);
 
+/// Return the share directory of the given package if found.
+/**
+ * \param[in] package_name the name of the package to locate.
+ * \param[out] path share path of the package.
+ * \return
+ * \throws PackageNotFoundError when the given package is not found.
+ */
+[[deprecated("Use get_package_share_path(...) instead")]]
+AMENT_INDEX_CPP_PUBLIC
+void
+get_package_share_directory(const std::string & package_name, std::filesystem::path & path);
+
 }  // namespace ament_index_cpp
 
 #endif  // AMENT_INDEX_CPP__GET_PACKAGE_SHARE_DIRECTORY_HPP_

--- a/ament_index_cpp/include/ament_index_cpp/get_package_share_path.hpp
+++ b/ament_index_cpp/include/ament_index_cpp/get_package_share_path.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Open Source Robotics Foundation, Inc.
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
-#include "ament_index_cpp/get_package_share_path.hpp"
+#ifndef AMENT_INDEX_CPP__GET_PACKAGE_SHARE_PATH_HPP_
+#define AMENT_INDEX_CPP__GET_PACKAGE_SHARE_PATH_HPP_
 
 #include <filesystem>
 #include <string>
 
-#include "ament_index_cpp/get_package_prefix.hpp"
+#include "ament_index_cpp/visibility_control.h"
 
 namespace ament_index_cpp
 {
 
-std::string
-get_package_share_directory(const std::string & package_name)
-{
-  return get_package_share_path(package_name).string();
-}
+/// Return the share directory of the given package if found.
+/**
+ * \param[in] package_name the name of the package to locate.
+ * \return share path of the package.
+ * \throws PackageNotFoundError when the given package is not found.
+ */
+AMENT_INDEX_CPP_PUBLIC
+std::filesystem::path
+get_package_share_path(const std::string & package_name);
 
 }  // namespace ament_index_cpp
+
+#endif  // AMENT_INDEX_CPP__GET_PACKAGE_SHARE_PATH_HPP_

--- a/ament_index_cpp/src/get_package_share_directory.cpp
+++ b/ament_index_cpp/src/get_package_share_directory.cpp
@@ -29,4 +29,11 @@ get_package_share_directory(const std::string & package_name)
   return get_package_share_path(package_name).string();
 }
 
+void get_package_share_directory(
+  const std::string & package_name,
+  std::filesystem::path & path)
+{
+  path = get_package_share_path(package_name);
+}
+
 }  // namespace ament_index_cpp

--- a/ament_index_cpp/src/get_package_share_path.cpp
+++ b/ament_index_cpp/src/get_package_share_path.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "ament_index_cpp/get_package_share_directory.hpp"
-#include "ament_index_cpp/get_package_share_path.hpp"
 
 #include <filesystem>
 #include <string>
@@ -23,10 +22,12 @@
 namespace ament_index_cpp
 {
 
-std::string
-get_package_share_directory(const std::string & package_name)
+std::filesystem::path get_package_share_path(
+  const std::string & package_name)
 {
-  return get_package_share_path(package_name).string();
+  std::filesystem::path result;
+  get_package_prefix(package_name, result);
+  return result / "share" / package_name;
 }
 
 }  // namespace ament_index_cpp

--- a/ament_index_cpp/src/get_package_share_path.cpp
+++ b/ament_index_cpp/src/get_package_share_path.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Open Source Robotics Foundation, Inc.
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ament_index_cpp/src/get_package_share_path.cpp
+++ b/ament_index_cpp/src/get_package_share_path.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 
 #include <filesystem>
 #include <string>

--- a/ament_index_cpp/test/utest.cpp
+++ b/ament_index_cpp/test/utest.cpp
@@ -249,8 +249,7 @@ TEST(AmentIndexCpp, get_package_share_directory) {
   subfolders.push_back("prefix2");  // only contains bar and baz packages
   set_ament_prefix_path(subfolders);
   // bar is in both, but prefix 1 takes precedence
-  std::filesystem::path path_result;
-  ament_index_cpp::get_package_share_directory("bar", path_result);
+  auto path_result = ament_index_cpp::get_package_share_directory("bar");
   EXPECT_EQ(
     std::filesystem::path(generate_subfolder_path("prefix1")) / "share" / "bar",
     path_result);

--- a/ament_index_cpp/test/utest.cpp
+++ b/ament_index_cpp/test/utest.cpp
@@ -22,7 +22,7 @@
 #include <string>
 
 #include "ament_index_cpp/get_package_prefix.hpp"
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 #include "ament_index_cpp/get_packages_with_prefixes.hpp"
 #include "ament_index_cpp/get_resource.hpp"
 #include "ament_index_cpp/get_resources.hpp"
@@ -242,14 +242,14 @@ TEST(AmentIndexCpp, get_package_prefix) {
     ament_index_cpp::PackageNotFoundError);
 }
 
-TEST(AmentIndexCpp, get_package_share_directory) {
+TEST(AmentIndexCpp, get_package_share_path) {
   // Ensure that a known to exist package is found and the share directory is correct.
   std::list<std::string> subfolders;
   subfolders.push_back("prefix1");  // only contains foo and bar packages
   subfolders.push_back("prefix2");  // only contains bar and baz packages
   set_ament_prefix_path(subfolders);
   // bar is in both, but prefix 1 takes precedence
-  auto path_result = ament_index_cpp::get_package_share_directory("bar");
+  auto path_result = ament_index_cpp::get_package_share_path("bar");
   EXPECT_EQ(
     std::filesystem::path(generate_subfolder_path("prefix1")) / "share" / "bar",
     path_result);


### PR DESCRIPTION
cpp and python were going out of sync.

Besides 
```c++
  auto dbc = ament_index_cpp::get_package_share_path("can_dbc_pkg") / "test" / "motohawk.dbc";
```

Looks much better than
```c++
  std::filesystem::path package_path;
  ament_index_cpp::get_package_share_directory("can_dbc_pkg", package_path);
  auto dbc = package_path / "test" / "motohawk.dbc";
```

Due to the short-livedness of the `get_package_share_directory(..., std::filesystem::path)` syntax, I didn't deprecated it.

I can finish this PR including the tests etc if that's appreciated. For now I wanted feedback first. :slightly_smiling_face: 