### PR TITLE
Guard filesystem for C++14 compatibility

### DIFF
--- a/ament_index_cpp/include/ament_index_cpp/get_package_share_directory.hpp
+++ b/ament_index_cpp/include/ament_index_cpp/get_package_share_directory.hpp
@@ -15,8 +15,11 @@
 #ifndef AMENT_INDEX_CPP__GET_PACKAGE_SHARE_DIRECTORY_HPP_
 #define AMENT_INDEX_CPP__GET_PACKAGE_SHARE_DIRECTORY_HPP_
 
-#include <filesystem>
 #include <string>
+
+#if __cplusplus >= 201703L
+#include <filesystem>
+#endif
 
 #include "ament_index_cpp/visibility_control.h"
 
@@ -40,9 +43,11 @@ get_package_share_directory(const std::string & package_name);
  * \return
  * \throws PackageNotFoundError when the given package is not found.
  */
+#if __cplusplus >= 201703L
 AMENT_INDEX_CPP_PUBLIC
 void
 get_package_share_directory(const std::string & package_name, std::filesystem::path & path);
+#endif
 
 }  // namespace ament_index_cpp
 


### PR DESCRIPTION
In https://github.com/ament/ament_index/commit/1bba98cb0d07128e34ffcfaecf087df8ce37bea7 a new overload of `get_package_share_directory()` that accepts a `std::filesystem::path &` output parameter was added. The public header unconditionally includes `<filesystem>` and declares the overload, making `<filesystem>` a required header for all consumers, including those compiling under `C++14`, where `<filesystem>` does not exist. 

This breaks any downstream package that includes `ament_index_cpp` headers while compiling with -std=c++14 or -std=gnu++14. For example, [behaviortree_cpp_v3](https://build.ros2.org/view/Jbin_uN64/job/Jbin_uN64__behaviortree_cpp_v3__ubuntu_noble_amd64__binary/94/console).

This PR adds guards the <filesystem> include and the new overload declaration behind `#if __cplusplus >= 201703L` to avoid the downstream breakage.