### PR TITLE
Add get_package_share_path (kilted backport)

### DIFF
--- a/ament_index_cpp/include/ament_index_cpp/get_package_share_directory.hpp
+++ b/ament_index_cpp/include/ament_index_cpp/get_package_share_directory.hpp
@@ -29,10 +29,6 @@ namespace ament_index_cpp
  * \return share path of the package.
  * \throws PackageNotFoundError when the given package is not found.
  */
-<<<<<<< HEAD
-=======
-[[deprecated("Use get_package_share_path(...) instead")]]
->>>>>>> acfcac6 (Use get_package_share_path just as python (#112))
 AMENT_INDEX_CPP_PUBLIC
 std::string
 get_package_share_directory(const std::string & package_name);
@@ -44,7 +40,6 @@ get_package_share_directory(const std::string & package_name);
  * \return
  * \throws PackageNotFoundError when the given package is not found.
  */
-[[deprecated("Use get_package_share_path(...) instead")]]
 AMENT_INDEX_CPP_PUBLIC
 void
 get_package_share_directory(const std::string & package_name, std::filesystem::path & path);

--- a/ament_index_cpp/src/get_package_share_directory.cpp
+++ b/ament_index_cpp/src/get_package_share_directory.cpp
@@ -26,22 +26,14 @@ namespace ament_index_cpp
 std::string
 get_package_share_directory(const std::string & package_name)
 {
-<<<<<<< HEAD
-  return get_package_prefix(package_name) + "/share/" + package_name;
-=======
   return get_package_share_path(package_name).string();
->>>>>>> acfcac6 (Use get_package_share_path just as python (#112))
 }
 
 void get_package_share_directory(
   const std::string & package_name,
   std::filesystem::path & path)
 {
-<<<<<<< HEAD
-  path = get_package_share_directory(package_name);
-=======
   path = get_package_share_path(package_name);
->>>>>>> acfcac6 (Use get_package_share_path just as python (#112))
 }
 
 }  // namespace ament_index_cpp

--- a/ament_index_cpp/test/utest.cpp
+++ b/ament_index_cpp/test/utest.cpp
@@ -253,13 +253,10 @@ TEST(AmentIndexCpp, get_package_share_path) {
   subfolders.push_back("prefix2");  // only contains bar and baz packages
   set_ament_prefix_path(subfolders);
   // bar is in both, but prefix 1 takes precedence
-<<<<<<< HEAD
-=======
   auto path_result = ament_index_cpp::get_package_share_path("bar");
->>>>>>> acfcac6 (Use get_package_share_path just as python (#112))
   EXPECT_EQ(
-    generate_subfolder_path("prefix1") + "/share/bar",
-    ament_index_cpp::get_package_share_directory("bar"));
+    std::filesystem::path(generate_subfolder_path("prefix1")) / "share" / "bar",
+    path_result);
 }
 
 TEST(AmentIndexCpp, get_packages_with_prefixes) {


### PR DESCRIPTION
Resolves conflicts in the automatic backport of #112 to kilted.
